### PR TITLE
Fix image tag from sha to version

### DIFF
--- a/pkg/cluster/internal/providers/docker/provision.go
+++ b/pkg/cluster/internal/providers/docker/provision.go
@@ -246,7 +246,7 @@ func runArgsForNode(node *config.Node, clusterIPFamily config.ClusterIPFamily, n
 	}
 
 	// finally, specify the image to run
-	return append(args, "stratio-capi-image:"+strings.Split(strings.Split(node.Image, "@")[1], ":")[1]), nil
+	return append(args, "stratio-capi-image:"+strings.Split(strings.Split(node.Image, "@")[0], ":")[1]), nil
 }
 
 func runArgsForLoadBalancer(cfg *config.Cluster, name string, args []string) ([]string, error) {


### PR DESCRIPTION
Al hacer el docker run usa la imagen (que contiene el sha):
'stratio-capi-image:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1'
en lugar de la imagen:
stratio-capi-image:v1.25.3