### PR TITLE
bump CAPA to v2.0.2

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/eksgen.go
+++ b/pkg/cluster/internal/create/actions/createworker/eksgen.go
@@ -107,7 +107,7 @@ func generateEKSManifest(secretsFile SecretsFile, descriptorFile DescriptorFile,
 
 	// TODO: Embeber los templates?
 	// TODO: Obtener capaVersion del cluster?
-	capaVersion := "v1.5.1"
+	capaVersion := "v2.0.2"
 	templates, _ := downloadTemplates(capaVersion)
 	templatesRAW := goyaml.NewDecoder(bytes.NewReader(templates))
 


### PR DESCRIPTION
so we can use bootstrap.cluster.x-k8s.io/v1beta2 and infrastructure.cluster.x-k8s.io/v1beta2