### PR TITLE
[EOS-10983] Make `external-dns` optional

### DIFF
--- a/pkg/cluster/internal/create/actions/cluster/cluster.go
+++ b/pkg/cluster/internal/create/actions/cluster/cluster.go
@@ -62,9 +62,9 @@ type DescriptorFile struct {
 		HostedZones bool `yaml:"hosted_zones" validate:"boolean"`
 	} `yaml:"dns"`
 
-	ExternalDomain string `yaml:"external_domain" validate:"omitempty,hostname"`
+	DockerRegistries []DockerRegistry `yaml:"docker_registries" validate:"dive"`
 
-	ExternalRegistry ExternalRegistry `yaml:"external_registry"`
+	ExternalDomain string `yaml:"external_domain" validate:"omitempty,hostname"`
 
 	Keos struct {
 		Domain  string `yaml:"domain" validate:"required,hostname"`

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -42,7 +42,7 @@ type KEOSDescriptor struct {
 			Ipip                 bool   `yaml:"ipip"`
 			Pool                 string `yaml:"pool"`
 			DeployTigeraOperator bool   `yaml:"deploy_tigera_operator"`
-		} `yaml:"calico"`
+		} `yaml:"calico,omitempty"`
 		ClusterID       string `yaml:"cluster_id"`
 		Dns struct {
 			ExternalDns  struct {

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -50,7 +50,7 @@ type KEOSDescriptor struct {
 			} `yaml:"external_dns,omitempty"`
 		} `yaml:"dns,omitempty"`
 		Domain          string `yaml:"domain"`
-		ExternalDomain  string `yaml:"external_domain"`
+		ExternalDomain  string `yaml:"external_domain,omitempty"`
 		Flavour         string `yaml:"flavour"`
 		K8sInstallation bool   `yaml:"k8s_installation"`
 		Storage         struct {


### PR DESCRIPTION
- Add `dns.hosted_zones` parameters to `cluster.yaml`. Default value `true`
- Add `keos.dns.external_dns.enabled` to `keos.yaml` depending on value `dns.hosted_zones`. Default value `true`

### Poyake

- `deploy_tigera_operator` set to `true` when provider is `managed`