### PR TITLE
Feature/eos 10999 create machine health check control plane

### DIFF
--- a/pkg/cluster/internal/create/actions/cluster/templates/aws.eks.tmpl
+++ b/pkg/cluster/internal/create/actions/cluster/templates/aws.eks.tmpl
@@ -85,7 +85,7 @@ spec:
   template:
     metadata:
       labels: 
-        stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
+        keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
     spec:
       clusterName: "{{ $.Descriptor.ClusterID }}"
       version: "{{ $.Descriptor.K8SVersion }}"
@@ -151,7 +151,7 @@ spec:
   nodeStartupTimeout: 300s
   selector:
     matchLabels:
-      stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
+      keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
   unhealthyConditions:
     - type: Ready
       status: Unknown

--- a/pkg/cluster/internal/create/actions/cluster/templates/aws.eks.tmpl
+++ b/pkg/cluster/internal/create/actions/cluster/templates/aws.eks.tmpl
@@ -104,10 +104,9 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: "{{ $node.Name }}-md-{{ $index }}"
-  namespace: "cluster-{{ $.Descriptor.ClusterID }}"    
+  namespace: "cluster-{{ $.Descriptor.ClusterID }}"
 spec:
   template:
-    metadata:
     spec:
       {{- if $node.Spot }}
       spotMarketOptions:

--- a/pkg/cluster/internal/create/actions/cluster/templates/aws.eks.tmpl
+++ b/pkg/cluster/internal/create/actions/cluster/templates/aws.eks.tmpl
@@ -83,6 +83,9 @@ spec:
   selector:
     matchLabels:
   template:
+    metadata:
+      labels: 
+        stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
     spec:
       clusterName: "{{ $.Descriptor.ClusterID }}"
       version: "{{ $.Descriptor.K8SVersion }}"
@@ -101,9 +104,10 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
   name: "{{ $node.Name }}-md-{{ $index }}"
-  namespace: "cluster-{{ $.Descriptor.ClusterID }}"
+  namespace: "cluster-{{ $.Descriptor.ClusterID }}"    
 spec:
   template:
+    metadata:
     spec:
       {{- if $node.Spot }}
       spotMarketOptions:
@@ -138,3 +142,21 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "{{ $.Descriptor.ClusterID }}-wn-node-unhealthy"
+spec:
+  clusterName: "{{ $.Descriptor.ClusterID }}"
+  nodeStartupTimeout: 300s
+  selector:
+    matchLabels:
+      stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 60s
+    - type: Ready
+      status: 'False'
+      timeout: 60s

--- a/pkg/cluster/internal/create/actions/cluster/templates/gcp.tmpl
+++ b/pkg/cluster/internal/create/actions/cluster/templates/gcp.tmpl
@@ -49,7 +49,7 @@ spec:
   machineTemplate:
     metadata:
       labels: 
-        stratio/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane-node"
+        keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane-node"
     infrastructureRef:
       kind: GCPMachineTemplate
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -147,7 +147,7 @@ spec:
   template:
     metadata:
       labels: 
-        stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
+        keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
     spec:
       clusterName: "{{ $.Descriptor.ClusterID }}"
       version: "{{ $.Descriptor.K8SVersion }}"
@@ -229,7 +229,7 @@ spec:
   nodeStartupTimeout: 300s
   selector:
     matchLabels:
-      stratio/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane"
+      keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane"
   unhealthyConditions:
     - type: Ready
       status: Unknown
@@ -247,7 +247,7 @@ spec:
   nodeStartupTimeout: 300s
   selector:
     matchLabels:
-      stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
+      keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
   unhealthyConditions:
     - type: Ready
       status: Unknown

--- a/pkg/cluster/internal/create/actions/cluster/templates/gcp.tmpl
+++ b/pkg/cluster/internal/create/actions/cluster/templates/gcp.tmpl
@@ -125,7 +125,7 @@ spec:
       {{- end }}
       {{- if .Descriptor.ControlPlane.RootVolume.Type }}
       rootDeviceType: {{ .Descriptor.ControlPlane.RootVolume.Type }}
-      {{- end }}        
+      {{- end }}
 {{- range $node := .Descriptor.WorkerNodes }}
 {{- range $index, $n := loop .AZ .ZoneDistribution .Quantity .NodeGroupMaxSize .NodeGroupMinSize }}
 ---

--- a/pkg/cluster/internal/create/actions/cluster/templates/gcp.tmpl
+++ b/pkg/cluster/internal/create/actions/cluster/templates/gcp.tmpl
@@ -47,6 +47,9 @@ metadata:
 spec:
   replicas: {{- if .Descriptor.ControlPlane.HighlyAvailable }} 3 {{- else }} 1 {{- end }}
   machineTemplate:
+    metadata:
+      labels: 
+        stratio/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane-node"
     infrastructureRef:
       kind: GCPMachineTemplate
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -122,7 +125,7 @@ spec:
       {{- end }}
       {{- if .Descriptor.ControlPlane.RootVolume.Type }}
       rootDeviceType: {{ .Descriptor.ControlPlane.RootVolume.Type }}
-      {{- end }}
+      {{- end }}        
 {{- range $node := .Descriptor.WorkerNodes }}
 {{- range $index, $n := loop .AZ .ZoneDistribution .Quantity .NodeGroupMaxSize .NodeGroupMinSize }}
 ---
@@ -142,6 +145,9 @@ spec:
   selector:
     matchLabels:
   template:
+    metadata:
+      labels: 
+        stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
     spec:
       clusterName: "{{ $.Descriptor.ClusterID }}"
       version: "{{ $.Descriptor.K8SVersion }}"
@@ -213,3 +219,39 @@ spec:
             node-labels: \"{{ if $node.Labels }}{{ range $key, $value := $node.Labels }}{{ $key }}={{ $value }},{{- end }}{{- end }}\"
 {{- end }}
 {{- end }}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "{{ $.Descriptor.ClusterID }}-controlplane-node-unhealthy"
+spec:
+  clusterName: "{{ $.Descriptor.ClusterID }}"
+  nodeStartupTimeout: 300s
+  selector:
+    matchLabels:
+      stratio/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane"
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 60s
+    - type: Ready
+      status: 'False'
+      timeout: 60s
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "{{ $.Descriptor.ClusterID }}-wn-node-unhealthy"
+spec:
+  clusterName: "{{ $.Descriptor.ClusterID }}"
+  nodeStartupTimeout: 300s
+  selector:
+    matchLabels:
+      stratio/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node"
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 60s
+    - type: Ready
+      status: 'False'
+      timeout: 60s

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -166,33 +166,6 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		return errors.Wrap(err, "failed to create cluster's Namespace")
 	}
 
-	var machineHealthCheck = `
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: ` + descriptorFile.ClusterID + `-node-unhealthy
-spec:
-  clusterName: ` + descriptorFile.ClusterID + `
-  nodeStartupTimeout: 300s
-  selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: ` + descriptorFile.ClusterID + `
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: 60s
-    - type: Ready
-      status: 'False'
-      timeout: 60s`
-
-	// Create the MachineHealthCheck manifest file in the container
-	machineHealthCheckPath := "/kind/manifests/machinehealthcheck.yaml"
-	raw = bytes.Buffer{}
-	cmd = node.Command("sh", "-c", "echo \""+machineHealthCheck+"\" > "+machineHealthCheckPath)
-	if err := cmd.SetStdout(&raw).Run(); err != nil {
-		return errors.Wrap(err, "failed to write the MachineHealthCheck manifest")
-	}
-
 	// Create the allow-all-egress network policy file in the container
 	allowAllEgressNetPolPath := "/kind/allow-all-egress_netpol.yaml"
 	raw = bytes.Buffer{}
@@ -295,20 +268,6 @@ spec:
 				return errors.Wrap(err, "failed to create the worker Cluster")
 			}
 		}
-
-		ctx.Status.End(true) // End Preparing nodes in workload cluster
-
-		ctx.Status.Start("Enabling workload cluster's self-healing 🏥")
-		defer ctx.Status.End(false)
-
-		// Enable the cluster's self-healing
-		raw = bytes.Buffer{}
-		cmd = node.Command("kubectl", "-n", capiClustersNamespace, "apply", "-f", machineHealthCheckPath)
-		if err := cmd.SetStdout(&raw).Run(); err != nil {
-			return errors.Wrap(err, "failed to apply the MachineHealthCheck manifest")
-		}
-
-		ctx.Status.End(true) // End Enabling workload cluster's self-healing
 
 		ctx.Status.Start("Installing CAPx in workload cluster 🎖️")
 		defer ctx.Status.End(false)


### PR DESCRIPTION
Hasta ahora el machineHealthCheck aplicaba sobre todas las máquinas que tuviesen la label:
cluster.x-k8s.io/cluster-name: ` + descriptorFile.ClusterID + `. Esto afectaba tanto a los nodos del controlplane como a los workernodes. 

Dado que las labels de los worker nodes estaban asociadas al cluster o al machineDeployment que las gestiona, había 2 opciones:
1. Añadir un MachineHealthCheck por MachineDeployment
2. Añadir un label nuevo a las Machine que las permita identificar por rol.

En esta PR se ha Templetizado el MachineHealthCheck y se ha añadido a los MachineDeployments esta etiqueta que se plantea en la opción 2:

- keos.stratio.com/machine-role: "{{ $.Descriptor.ClusterID }}-worker-node" Para los nodos workers
- keos.stratio.co/machine-role: "{{ $.Descriptor.ClusterID }}-control-plane-node". Para los controlplane

De este modo podemos aplicar distintos MachineHealthCheck, en función del tipo de nodo