### PR TITLE
fix: condition met before get kubeconfig

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -252,14 +252,14 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 		// Wait for the worker cluster creation
 		raw = bytes.Buffer{}
-		cmd = node.Command("kubectl", "-n", capiClustersNamespace, "wait", "--for=condition=ready", "--timeout", "25m", "cluster", descriptorFile.ClusterID)
+		cmd = node.Command("kubectl", "-n", capiClustersNamespace, "wait", "--for=condition=ControlPlaneInitialized", "--timeout", "25m", "cluster", descriptorFile.ClusterID)
 		if err := cmd.SetStdout(&raw).Run(); err != nil {
 			return errors.Wrap(err, "failed to create the worker Cluster")
 		}
 
 		// Get the workload cluster kubeconfig
 		raw = bytes.Buffer{}
-		cmd = node.Command("sh", "-c", "clusterctl -n "+capiClustersNamespace+" get kubeconfig "+descriptorFile.ClusterID+" | tee "+kubeconfigPath)
+		cmd = node.Command("sh", "-c", "clusterctl -n "+capiClustersNamespace+" get kubeconfig "+descriptorFile.ClusterID+" > "+kubeconfigPath)
 		if err := cmd.SetStdout(&raw).Run(); err != nil {
 			return errors.Wrap(err, "failed to get workload cluster kubeconfig")
 		}


### PR DESCRIPTION
kubeconfig is created when `cluster.Spec.ControlPlaneEndpoint` (internal/controllers/cluster/cluster_controller_phases.go)(util/kubeconfig/kubeconfig.go)
`ControlPlaneReady` is `true` when  the Ready condition in the control plane ref object is `true` (api/v1alpha4/condition_consts.go)(controllers/external/util.go)
`ControlPlaneInitialized` is `true`  when cluster's apiserver is reachable and at least one control plane Machine has a node reference (api/v1alpha4/condition_consts.go)(controllers/external/util.go)
`Ready` is `true` when `InfrastructureReady` and `ControlPlaneReady` are `true` (internal/controllers/cluster/cluster_controller.go)

Almost all of them at same time except when control plane is managed (https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/78877789bc4ab25912ae9383ad5cc2f291982270/pkg/cloud/services/eks/config.go#LL74C2-L74C48)

todo empieza en --> (internal/controllers/cluster/cluster_controller.go)
