### PR TITLE
[EOS-11130] Handle keos domain parameter

### DIFF
--- a/pkg/cluster/internal/create/actions/cluster/cluster.go
+++ b/pkg/cluster/internal/create/actions/cluster/cluster.go
@@ -64,7 +64,8 @@ type DescriptorFile struct {
 	ExternalDomain string `yaml:"external_domain" validate:"omitempty,hostname"`
 
 	Keos struct {
-		Domain  string `yaml:"domain" validate:"required,hostname"`
+		// PR fixing exclude_if behaviour https://github.com/go-playground/validator/pull/939
+		Domain  string `yaml:"domain" validate:"omitempty,hostname"`
 		Flavour string `yaml:"flavour"`
 		Version string `yaml:"version"`
 	} `yaml:"keos"`

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -49,7 +49,8 @@ type KEOSDescriptor struct {
 				Enabled *bool `yaml:"enabled,omitempty"`
 			} `yaml:"external_dns,omitempty"`
 		} `yaml:"dns,omitempty"`
-		Domain          string `yaml:"domain"`
+		// PR fixing exclude_if behaviour https://github.com/go-playground/validator/pull/939
+		Domain          string `yaml:"domain,omitempty"`
 		ExternalDomain  string `yaml:"external_domain,omitempty"`
 		Flavour         string `yaml:"flavour"`
 		K8sInstallation bool   `yaml:"k8s_installation"`
@@ -88,7 +89,11 @@ func createKEOSDescriptor(descriptorFile cluster.DescriptorFile, storageClass st
 
 	// Keos
 	keosDescriptor.Keos.ClusterID = descriptorFile.ClusterID
-	keosDescriptor.Keos.Domain = descriptorFile.Keos.Domain
+        if descriptorFile.InfraProvider == "aws" {
+                keosDescriptor.Keos.Domain = "cluster.local"
+        } else if descriptorFile.Keos.Domain != "" {
+                keosDescriptor.Keos.Domain = descriptorFile.Keos.Domain
+        }
 	if descriptorFile.ExternalDomain != "" {
 		keosDescriptor.Keos.ExternalDomain = descriptorFile.ExternalDomain
 	}


### PR DESCRIPTION
# AWS
`keos.domain` always takes the value of `cluster.local`

# GCP and others
if `spec.keos.domain` has a value in `cluster.yaml` `keos.domain` takes always that value in `keos.yaml`
if `spec.keos.domain` doesn't exist in `cluster.yaml` `keos.domain` will not exist in `keos.yaml` (by default in keos-installer it will take the default value of `$cluster_id.int`)