### PR TITLE
fix: align account param with keos

### DIFF
--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -163,7 +163,7 @@ type AWSCredentials struct {
 	AccessKey string `yaml:"access_key"`
 	SecretKey string `yaml:"secret_key"`
 	Region    string `yaml:"region"`
-	Account   string `yaml:"account"`
+	Account   string `yaml:"account_id"`
 }
 
 type GCPCredentials struct {


### PR DESCRIPTION
https://github.com/Stratio/keos-installer/blob/43ae7aa719fcfaf2a8fd9779f4b2b4864271432d/ansible/inventory/group_vars/all/01-aws.yml#L5