### PR TITLE
[EOS-11148] Refinar el uso de un CIDR (secundario) específico para Pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v1.0.0
 	github.com/alessio/shellescape v1.4.1
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.228
 	github.com/aws/aws-sdk-go-v2/config v1.18.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.17

--- a/go.sum
+++ b/go.sum
@@ -540,6 +540,8 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/aws/aws-sdk-go v1.44.228 h1:CkkAlgNFf7qPZy/bAssF6lafR/ThMiiwKQEHVfPJixc=
 github.com/aws/aws-sdk-go v1.44.228/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.17.6 h1:Y773UK7OBqhzi5VDXMi1zVGsoj+CVHs2eaC2bDsLwi0=

--- a/pkg/cluster/internal/create/actions/createworker/templates/aws.eks.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/aws.eks.tmpl
@@ -48,8 +48,8 @@ spec:
     vpc:
       availabilityZoneSelection: {{- if ne .Descriptor.Networks.AvailabilityZoneSelection "" }} {{ .Descriptor.Networks.AvailabilityZoneSelection }} {{ else }} Ordered {{ end }}
       availabilityZoneUsageLimit: {{- if ne .Descriptor.Networks.AvailabilityZoneUsageLimit 0 }} {{ .Descriptor.Networks.AvailabilityZoneUsageLimit }} {{ else }} 3 {{ end }}
-  {{- if ne .Descriptor.Networks.PrimaryCidrBlock "" }}
-      cidrBlock: {{ .Descriptor.Networks.PrimaryCidrBlock }}
+  {{- if ne .Descriptor.Networks.VPCCidrBlock "" }}
+      cidrBlock: {{ .Descriptor.Networks.VPCCidrBlock }}
   {{- end }}
   {{- if isNotEmpty .Descriptor.Networks.Tags }}
       tags:
@@ -88,8 +88,8 @@ spec:
     {{- end }}
 {{- end }}
   region: "{{ .Descriptor.Region }}"
-{{- if ne .Descriptor.Networks.SecondaryCidrBlock "" }}
-  secondaryCidrBlock: {{ .Descriptor.Networks.SecondaryCidrBlock }}
+{{- if ne .Descriptor.Networks.PodsCidrBlock "" }}
+  secondaryCidrBlock: {{ .Descriptor.Networks.PodsCidrBlock }}
 {{- end }}
   sshKeyName: \"{{ .Descriptor.Bastion.SSHKey }}\"
   version: "{{ .Descriptor.K8SVersion }}"
@@ -97,7 +97,7 @@ spec:
     env:
       - name: ANNOTATE_POD_IP
         value: \"true\"
-    {{- if ne .Descriptor.Networks.SecondaryCidrBlock "" }}
+    {{- if ne .Descriptor.Networks.PodsCidrBlock "" }}
       - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
         value: \"true\"
       - name: ENI_CONFIG_LABEL_DEF

--- a/pkg/cluster/internal/create/actions/createworker/templates/aws.eks.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/aws.eks.tmpl
@@ -48,8 +48,8 @@ spec:
     vpc:
       availabilityZoneSelection: {{- if ne .Descriptor.Networks.AvailabilityZoneSelection "" }} {{ .Descriptor.Networks.AvailabilityZoneSelection }} {{ else }} Ordered {{ end }}
       availabilityZoneUsageLimit: {{- if ne .Descriptor.Networks.AvailabilityZoneUsageLimit 0 }} {{ .Descriptor.Networks.AvailabilityZoneUsageLimit }} {{ else }} 3 {{ end }}
-  {{- if ne .Descriptor.Networks.CidrBlock "" }}
-      cidrBlock: {{ .Descriptor.Networks.CidrBlock }}
+  {{- if ne .Descriptor.Networks.PrimaryCidrBlock "" }}
+      cidrBlock: {{ .Descriptor.Networks.PrimaryCidrBlock }}
   {{- end }}
   {{- if isNotEmpty .Descriptor.Networks.Tags }}
       tags:
@@ -88,12 +88,21 @@ spec:
     {{- end }}
 {{- end }}
   region: "{{ .Descriptor.Region }}"
+{{- if ne .Descriptor.Networks.SecondaryCidrBlock "" }}
+  secondaryCidrBlock: {{ .Descriptor.Networks.SecondaryCidrBlock }}
+{{- end }}
   sshKeyName: \"{{ .Descriptor.Bastion.SSHKey }}\"
   version: "{{ .Descriptor.K8SVersion }}"
   vpcCni:
     env:
       - name: ANNOTATE_POD_IP
         value: \"true\"
+    {{- if ne .Descriptor.Networks.SecondaryCidrBlock "" }}
+      - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+        value: \"true\"
+      - name: ENI_CONFIG_LABEL_DEF
+        value: \"topology.kubernetes.io/zone\"
+    {{- end }}
 {{- range $node := .Descriptor.WorkerNodes }}
 {{- range $index, $n := loop .AZ .ZoneDistribution .Quantity .NodeGroupMaxSize .NodeGroupMinSize }}
 ---

--- a/pkg/cmd/kind/create/cluster/validation/eksvalidator.go
+++ b/pkg/cmd/kind/create/cluster/validation/eksvalidator.go
@@ -65,6 +65,22 @@ func descriptorEksValidations(descriptorFile commons.DescriptorFile) error {
 	if err != nil {
 		return err
 	}
+	err = validateVPCCidr(descriptorFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func secretsEksValidations(secretsFile commons.SecretsFile) error {
+	err := commonsSecretsValidations(secretsFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateVPCCidr(descriptorFile commons.DescriptorFile) error {
 	if descriptorFile.Networks.PrimaryCidrBlock != "" {
 		_, ipv4Net, _ := net.ParseCIDR(descriptorFile.Networks.PrimaryCidrBlock)
 		cidrSize := cidr.AddressCount(ipv4Net)
@@ -87,14 +103,6 @@ func descriptorEksValidations(descriptorFile commons.DescriptorFile) error {
 		if (!validRange1.Contains(start) || !validRange1.Contains(end)) && (!validRange2.Contains(start) || !validRange2.Contains(end)) {
 			return errors.New("Invalid parameter SecondaryCidrBlock, CIDR must be within the 100.64.0.0/10 or 198.19.0.0/16 range")
 		}
-	}
-	return nil
-}
-
-func secretsEksValidations(secretsFile commons.SecretsFile) error {
-	err := commonsSecretsValidations(secretsFile)
-	if err != nil {
-		return err
 	}
 	return nil
 }

--- a/pkg/cmd/kind/create/cluster/validation/eksvalidator.go
+++ b/pkg/cmd/kind/create/cluster/validation/eksvalidator.go
@@ -81,27 +81,27 @@ func secretsEksValidations(secretsFile commons.SecretsFile) error {
 }
 
 func validateVPCCidr(descriptorFile commons.DescriptorFile) error {
-	if descriptorFile.Networks.PrimaryCidrBlock != "" {
-		_, ipv4Net, _ := net.ParseCIDR(descriptorFile.Networks.PrimaryCidrBlock)
+	if descriptorFile.Networks.VPCCidrBlock != "" {
+		_, ipv4Net, _ := net.ParseCIDR(descriptorFile.Networks.VPCCidrBlock)
 		cidrSize := cidr.AddressCount(ipv4Net)
 		if cidrSize > cidrSizeMax || cidrSize < cidrSizeMin {
-			return errors.New("Invalid parameter PrimaryCidrBlock, CIDR block sizes must be between a /16 netmask and /28 netmask")
+			return errors.New("Invalid parameter VPCCidrBlock, CIDR block sizes must be between a /16 netmask and /28 netmask")
 		}
 	}
-	if descriptorFile.Networks.SecondaryCidrBlock != "" {
+	if descriptorFile.Networks.PodsCidrBlock != "" {
 		_, validRange1, _ := net.ParseCIDR("100.64.0.0/10")
 		_, validRange2, _ := net.ParseCIDR("198.19.0.0/16")
 
-		_, ipv4Net, _ := net.ParseCIDR(descriptorFile.Networks.SecondaryCidrBlock)
+		_, ipv4Net, _ := net.ParseCIDR(descriptorFile.Networks.PodsCidrBlock)
 
 		cidrSize := cidr.AddressCount(ipv4Net)
 		if cidrSize > cidrSizeMax || cidrSize < cidrSizeMin {
-			return errors.New("Invalid parameter SecondaryCidrBlock, CIDR block sizes must be between a /16 netmask and /28 netmask")
+			return errors.New("Invalid parameter PodsCidrBlock, CIDR block sizes must be between a /16 netmask and /28 netmask")
 		}
 
 		start, end := cidr.AddressRange(ipv4Net)
 		if (!validRange1.Contains(start) || !validRange1.Contains(end)) && (!validRange2.Contains(start) || !validRange2.Contains(end)) {
-			return errors.New("Invalid parameter SecondaryCidrBlock, CIDR must be within the 100.64.0.0/10 or 198.19.0.0/16 range")
+			return errors.New("Invalid parameter PodsCidrBlock, CIDR must be within the 100.64.0.0/10 or 198.19.0.0/16 range")
 		}
 	}
 	return nil

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -86,8 +86,8 @@ type DescriptorFile struct {
 
 type Networks struct {
 	VPCID                      string            `yaml:"vpc_id"`
-	PrimaryCidrBlock           string            `yaml:"primary_cidr" validate:"omitempty,cidrv4"`
-	SecondaryCidrBlock         string            `yaml:"secondary_cidr" validate:"omitempty,cidrv4"`
+	VPCCidrBlock           string            `yaml:"vpc_cidr" validate:"omitempty,cidrv4"`
+	PodsCidrBlock         string            `yaml:"pods_cidr" validate:"omitempty,cidrv4"`
 	Tags                       map[string]string `yaml:"tags,omitempty"`
 	AvailabilityZoneUsageLimit int               `yaml:"az_usage_limit" validate:"numeric"`
 	AvailabilityZoneSelection  string            `yaml:"az_selection" validate:"oneof='Ordered' 'Random' '' "`

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -86,7 +86,8 @@ type DescriptorFile struct {
 
 type Networks struct {
 	VPCID                      string            `yaml:"vpc_id"`
-	CidrBlock                  string            `yaml:"cidr,omitempty"`
+	PrimaryCidrBlock           string            `yaml:"primary_cidr" validate:"omitempty,cidrv4"`
+	SecondaryCidrBlock         string            `yaml:"secondary_cidr" validate:"omitempty,cidrv4"`
 	Tags                       map[string]string `yaml:"tags,omitempty"`
 	AvailabilityZoneUsageLimit int               `yaml:"az_usage_limit" validate:"numeric"`
 	AvailabilityZoneSelection  string            `yaml:"az_selection" validate:"oneof='Ordered' 'Random' '' "`


### PR DESCRIPTION
[Managed (dynamic) VPC](https://cluster-api-aws.sigs.k8s.io/topics/eks/pod-networking.html#managed-dynamic-vpc)

Default configuration for CAPA is to manage the VPC and all the subnets for you dynamically. It will create and delete them along with your cluster. In this method all you need to do is set a SecondaryCidrBlock to one of the allowed two IPv4 CIDR blocks: 100.64.0.0/10 and 198.19.0.0/16. CAPA will automatically generate subnets and ENIConfigs for you and the VPC CNI will do the rest.

[Unmanaged (static) VPC](https://cluster-api-aws.sigs.k8s.io/topics/eks/pod-networking.html#unmanaged-static-vpc)

In an unmanaged VPC configuration CAPA will create no VPC or subnets and will instead assign the cluster pieces to the IDs you pass. In order to get ENIConfigs to generate you will need to add tags to the subnet you created and want to use as the secondary subnets for your pods. This is done through tagging the subnets with the following tag: sigs.k8s.io/cluster-api-provider-aws/association=secondary.

## Constraints

- Set a SecondaryCidrBlock to one of the allowed two IPv4 CIDR blocks: 100.64.0.0/10 and 198.19.0.0/16
-  Specify an IPv4 CIDR block for the VPC. The allowed block size is between a /16 netmask (65,536 IP addresses) and /28 netmask (16 IP addresses).

## cluster.yaml example
### Managed
```
kind: KeosCluster
spec:
    cluster_id: <cluster-name>
    control_plane:
        aws:
            associateOIDCProvider: true
            logging:
                api_server: true
                controller_manager: true
        managed: true
    docker_registries:
        - auth_required: false
          type: ecr
          url: 268367799918.dkr.ecr.eu-west-1.amazonaws.com/keos
          keos_registry: true
    networks:
        vpc_cidr: 10.0.0.0/16
        pods_cidr: 100.64.0.0/16
    external_domain: <external-domain>
    infra_provider: aws
    k8s_version: v1.24.0
    keos:
        domain: cluster.local
        flavour: minimal
        version: 0.8.0
    region: eu-west-1
    worker_nodes:
        - name: <worker-nodes>
          quantity: 4
          max_size: 15
          min_size: 3
          root_volume:
            encrypted: false
            size: 20
            type: gp3
          size: t3.medium
```
### Unmanaged
```
apiVersion: installer.stratio.com/v1beta1
kind: KeosCluster
spec:
    cluster_id: <cluster-name>
    control_plane:
        aws:
            associateOIDCProvider: true
            logging:
                api_server: true
                controller_manager: true
        managed: true
    docker_registries:
        - auth_required: false
          type: ecr
          url: 268367799918.dkr.ecr.eu-west-1.amazonaws.com/keos
          keos_registry: true
    networks:
        vpc_id: vpc-0d391a2ed51ba27ba
        # Must be specifed until stable version https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3688/files
        pods_cidr: 100.64.0.0/16
        subnets:
            - subnet_id: subnet-029996d4a861daa4d
            - subnet_id: subnet-0aacad0fbdebdd74b
            - subnet_id: subnet-064252b8054e124b6
            - subnet_id: subnet-07be9588b04db0f4d
            - subnet_id: subnet-0da3708804ce0ab5a
            - subnet_id: subnet-0fe9b340af99db67e
            - subnet_id: subnet-06b40b6efb51130dd
            - subnet_id: subnet-008bea84221f5a826
            - subnet_id: subnet-0efc3cc9b62c73374
    external_domain: <external-domain>
    infra_provider: aws
    k8s_version: v1.24.0
    keos:
        domain: cluster.local
        flavour: minimal
        version: 0.8.0
    region: eu-west-1
    worker_nodes:
        - name: <worker-nodes>
          quantity: 4
          max_size: 15
          min_size: 1
          root_volume:
            encrypted: false
            size: 20
            type: gp3
          size: t3.xlarge
```

## How to test

Install cloud-provisioner and keos-installer and verify nodes and pods IPs correspond to different subnets.