### PR TITLE
[EOS-1144][GCP] Usar additionalNetworkTags para quitar dependencia de cluster_name en grupo de nodos

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/templates/gcp.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/gcp.tmpl
@@ -214,6 +214,7 @@ metadata:
 spec:
   template:
     spec:
+      additionalNetworkTags: ["{{ $node.Name }}-md-{{ $index }}"]
       instanceType: "{{ $node.Size }}"
       image: "{{ $node.NodeImage }}"
       {{- if $node.RootVolume.Size }}


### PR DESCRIPTION
`.spec.worker_nodes[].name` containing `spec.cluster_id`  is not mandatory anymore.

Example:
```
apiVersion: installer.stratio.com/v1beta1
kind: KeosCluster
spec:
    cluster_id: xxxxxxxxxx
    infra_provider: gcp
    k8s_version: v1.24.10
    region: europe-west4
    docker_registries:
        - url: eosregistry.azurecr.io/keos
          auth_required: true
          type: generic
          keos_registry: true
    keos:
        domain: cluster.local
        flavour: minimal
        version: 0.8.0
        calico:
            pool: 10.1.0.0/16
    control_plane:
        managed: false
        size: n2-standard-2
        node_image: projects/clusterapi-369611/global/images/cluster-api-ubuntu-2204-v1-23-15-1679931010
        root_volume:
            size: 50
            type: pd-ssd
    worker_nodes:
        - name: workers-1
          quantity: 4
          max_size: 8
          min_size: 3
          zone_distribution: balanced
          size: n2-standard-2
          node_image: projects/clusterapi-369611/global/images/cluster-api-ubuntu-2204-v1-23-15-1679931010
          labels:
            disktype: standard
          root_volume:
            size: 50
```