### PR TITLE
[EOS-11436] Configurar EFS en el descriptor (para renderizar el keos.yaml)

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -18,6 +18,8 @@ package createworker
 
 import (
 	"os"
+	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/kind/pkg/commons"
@@ -61,10 +63,22 @@ type KEOSDescriptor struct {
 		Flavour         string `yaml:"flavour"`
 		K8sInstallation bool   `yaml:"k8s_installation"`
 		Storage         struct {
-			DefaultStorageClass string   `yaml:"default_storage_class"`
+			DefaultStorageClass string   `yaml:"default_storage_class,omitempty"`
 			Providers           []string `yaml:"providers"`
+			Config              struct {
+				CSIAWS struct {
+					EFS      []EFSConfig `yaml:"efs"`
+					KMSKeyID string      `yaml:"kms_key_id,omitempty"`
+				} `yaml:"csi-aws"`
+			} `yaml:"config,omitempty"`
 		} `yaml:"storage"`
-	} `yaml:"keos"`
+	}
+}
+
+type EFSConfig struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Permissions string `yaml:"permissions"`
 }
 
 func createKEOSDescriptor(descriptorFile commons.DescriptorFile, storageClass string) error {
@@ -124,8 +138,30 @@ func createKEOSDescriptor(descriptorFile commons.DescriptorFile, storageClass st
 	keosDescriptor.Keos.Calico.DeployTigeraOperator = false
 
 	// Keos - Storage
-	keosDescriptor.Keos.Storage.DefaultStorageClass = storageClass
-	keosDescriptor.Keos.Storage.Providers = []string{"custom"}
+	if descriptorFile.StorageClass.EFS.Name != "" {
+		keosDescriptor.Keos.Storage.Providers = []string{"csi-aws"}
+
+		name := descriptorFile.StorageClass.EFS.Name
+		id := descriptorFile.StorageClass.EFS.ID
+		permissions := descriptorFile.StorageClass.EFS.Permissions
+
+		if permissions == "" {
+			permissions = "700"
+		}
+		keosDescriptor.Keos.Storage.Config.CSIAWS.EFS = []EFSConfig{
+			{
+				Name:        name,
+				ID:          id,
+				Permissions: permissions,
+			},
+		}
+		if descriptorFile.StorageClass.EncryptionKey != "" {
+			keosDescriptor.Keos.Storage.Config.CSIAWS.KMSKeyID = descriptorFile.StorageClass.EncryptionKey
+		}
+	} else {
+		keosDescriptor.Keos.Storage.DefaultStorageClass = storageClass
+		keosDescriptor.Keos.Storage.Providers = []string{"custom"}
+	}
 
 	// Keos - External dns
 	if !descriptorFile.Dns.ManageZone {
@@ -135,6 +171,20 @@ func createKEOSDescriptor(descriptorFile commons.DescriptorFile, storageClass st
 	keosYAMLData, err := yaml.Marshal(keosDescriptor)
 	if err != nil {
 		return err
+	}
+
+	// Rotate keos.yaml
+	keosFilename := "keos.yaml"
+
+	if _, err := os.Stat(keosFilename); err == nil {
+		timestamp := time.Now().Format("2006-01-02@15:04:05")
+		backupKeosFilename := keosFilename + "." + timestamp + "~"
+		originalKeosFilePath := filepath.Join(".", keosFilename)
+		backupKeosFilePath := filepath.Join(".", backupKeosFilename)
+
+		if err := os.Rename(originalKeosFilePath, backupKeosFilePath); err != nil {
+			return err
+		}
 	}
 
 	// Write file to disk

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -138,6 +138,7 @@ func createKEOSDescriptor(descriptorFile commons.DescriptorFile, storageClass st
 	keosDescriptor.Keos.Calico.DeployTigeraOperator = false
 
 	// Keos - Storage
+	keosDescriptor.Keos.Storage.DefaultStorageClass = storageClass
 	if descriptorFile.StorageClass.EFS.Name != "" {
 		keosDescriptor.Keos.Storage.Providers = []string{"csi-aws"}
 
@@ -159,7 +160,6 @@ func createKEOSDescriptor(descriptorFile commons.DescriptorFile, storageClass st
 			keosDescriptor.Keos.Storage.Config.CSIAWS.KMSKeyID = descriptorFile.StorageClass.EncryptionKey
 		}
 	} else {
-		keosDescriptor.Keos.Storage.DefaultStorageClass = storageClass
 		keosDescriptor.Keos.Storage.Providers = []string{"custom"}
 	}
 

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -241,12 +241,14 @@ type Secrets struct {
 }
 
 type StorageClass struct {
-	EFS struct {
-		Name        string `yaml:"name" validate:"required_with=ID"`
-		ID          string `yaml:"id" validate:"required_with=Name"`
-		Permissions string `yaml:"permissions,omitempty"`
-	} `yaml:"efs"`
+	EFS           EFS    `yaml:"efs"`
 	EncryptionKey string `yaml:"encryption_key,omitempty"`
+}
+
+type EFS struct {
+	Name        string `yaml:"name" validate:"required_with=ID"`
+	ID          string `yaml:"id" validate:"required_with=Name"`
+	Permissions string `yaml:"permissions,omitempty"`
 }
 
 type ProviderParams struct {

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -80,6 +80,7 @@ type DescriptorFile struct {
 		ExtraVolumes []ExtraVolume `yaml:"extra_volumes"`
 	} `yaml:"control_plane"`
 
+	StorageClass StorageClass `yaml:storageclass`
 	WorkerNodes WorkerNodes `yaml:"worker_nodes" validate:"required,dive"`
 }
 
@@ -231,6 +232,15 @@ type Secrets struct {
 	GithubToken      string                      `yaml:"github_token"`
 	ExternalRegistry DockerRegistryCredentials   `yaml:"external_registry"`
 	DockerRegistries []DockerRegistryCredentials `yaml:"docker_registries"`
+}
+
+type StorageClass struct {
+	EFS struct {
+		Name        string `yaml:"name" validate:"required_with=ID"`
+		ID          string `yaml:"id" validate:"required_with=Name"`
+		Permissions string `yaml:"permissions,omitempty"`
+	} `yaml:"efs"`
+	EncryptionKey string `yaml:"encryption_key,omitempty"`
 }
 
 type ProviderParams struct {


### PR DESCRIPTION
## EKS

cluster.yaml
```
...
    storageclass:
        efs:
            name: fs-015ea5e2ba5fe7fa5
            id: fs-015ea5e2ba5fe7fa5
            permissions: 640
...
```
keos.yaml
```
...
    storage:
        providers:
            - csi-aws
        config:
            csi-aws:
                efs:
                    - id: fs-015ea5e2ba5fe7fa5
                      name: support-efs-capi
                      permissions: "640"
...
```

### ***Poyake

Rotate keos.yaml each execution of cloud-provisioner