### PR TITLE
Chore/vault password

### DIFF
--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -54,6 +54,7 @@ func DisplayVersion() string {
 }
 
 // versionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
+
 const versionCore = "0.17.0-0.4.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -54,7 +54,6 @@ func DisplayVersion() string {
 }
 
 // versionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
-
 const versionCore = "0.17.0-0.4.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per


### PR DESCRIPTION
_**Scenario 1**_ - If credentials exist in cluster.yaml, request the Vault password twice.

**_Scenario 2_** - If credentials exist in secret.yaml, request the Vault password only once.

**_Scenario 3_** - If passwords requested twice don't match
```bash
ERROR: The passwords do not match.
```

**_Scenario 4_** - If credentials exist in secret.yaml but requested password doesn't match
```bash
ERROR: failed to validate cluster: the vaultPassword is incorrect
```

**_Scenario 5_** - If credentials don't exist in either cluster.yaml or secrets.yaml
```bash
ERROR: Failed to validate the cluster: There are no Azure credentials in the descriptor or secrets file.
```