### PR TITLE
Added annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.0-0.3.5 (2023-12-1)
+
+*[Core] Added cluster-autoscaler annotation to evict local volumes
+
 ## 0.17.0-0.3.4 (2023-11-17)
 
 * [Core] Conditionally increase replicas for capi controllers

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -656,6 +656,16 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		}
 	}
 
+	ctx.Status.Start("Executing post-install steps 🎖️")
+	defer ctx.Status.End(false)
+
+	err = infra.postInstallPhase(n, kubeconfigPath)
+	if err != nil {
+		return err
+	}
+
+	ctx.Status.End(true)
+
 	ctx.Status.Start("Generating the KEOS descriptor 📝")
 	defer ctx.Status.End(false)
 

--- a/pkg/cluster/internal/create/actions/createworker/files/common/coredns_pdb.yaml
+++ b/pkg/cluster/internal/create/actions/createworker/files/common/coredns_pdb.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  labels:
+    k8s-app: kube-dns
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/pkg/cluster/internal/create/actions/createworker/files/gcp/gcp-compute-persistent-disk-csi-driver.yaml
+++ b/pkg/cluster/internal/create/actions/createworker/files/gcp/gcp-compute-persistent-disk-csi-driver.yaml
@@ -416,6 +416,8 @@ spec:
       app: gcp-compute-persistent-disk-csi-driver
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:

--- a/pkg/cluster/internal/create/actions/createworker/gcp.go
+++ b/pkg/cluster/internal/create/actions/createworker/gcp.go
@@ -262,3 +262,8 @@ func (b *GCPBuilder) getOverrideVars(p ProviderParams, networks commons.Networks
 	}
 	return overrideVars, nil
 }
+
+func (b *GCPBuilder) postInstallPhase(n nodes.Node, k string) error {
+
+	return nil
+}

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -922,7 +922,7 @@ func rolloutStatus(n nodes.Node, k string, ns string, deployName string) error {
 func installCorednsPdb(n nodes.Node, k string) error {
 
 	// Define PodDisruptionBudget for coredns service
-	corednsPDBLocalPath := "files/commons/coredns_pdb.yaml"
+	corednsPDBLocalPath := "files/common/coredns_pdb.yaml"
 	corednsPDB, err := getcapxPDB(corednsPDBLocalPath)
 	if err != nil {
 		return err

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/calico-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/calico-helm-values.tmpl
@@ -17,17 +17,17 @@ certs:
 imagePullSecrets: {}
 installation:
   calicoNetwork:
-    bgp: {{- if or ($.ControlPlane.Managed) (eq $.InfraProvider "azure") }} Disabled {{- else }} Enabled {{- end }}
-  {{- if not $.ControlPlane.Managed }}
-    {{- if eq $.InfraProvider "azure" }}
+    bgp: {{- if or ($.Spec.ControlPlane.Managed) (eq $.Spec.InfraProvider "azure") }} Disabled {{- else }} Enabled {{- end }}
+  {{- if not $.Spec.ControlPlane.Managed }}
+    {{- if eq $.Spec.InfraProvider "azure" }}
     mtu: 1350
     {{- end }}
     ipPools:
-      - cidr: {{- if $.Networks.PodsCidrBlock }} {{ $.Networks.PodsCidrBlock }} {{- else }} 192.168.0.0/16 {{- end }}
-        encapsulation: {{- if eq $.InfraProvider "azure" }} VXLAN {{- else }} IPIP {{- end }}
+      - cidr: {{- if $.Spec.Networks.PodsCidrBlock }} {{ $.Spec.Networks.PodsCidrBlock }} {{- else }} 192.168.0.0/16 {{- end }}
+        encapsulation: {{- if eq $.Spec.InfraProvider "azure" }} VXLAN {{- else }} IPIP {{- end }}
   {{- end }}
   cni:
-  {{- if and ($.ControlPlane.Managed) (eq $.InfraProvider "aws") }}
+  {{- if and ($.Spec.ControlPlane.Managed) (eq $.Spec.InfraProvider "aws") }}
     ipam:
       type: AmazonVPC
     type: AmazonVPC
@@ -37,7 +37,7 @@ installation:
     type: Calico
   {{- end }}
   enabled: true
-  kubernetesProvider: {{- if and ($.ControlPlane.Managed) (eq $.InfraProvider "aws") }} EKS {{- else }} "" {{- end }}
+  kubernetesProvider: {{- if and ($.Spec.ControlPlane.Managed) (eq $.Spec.InfraProvider "aws") }} EKS {{- else }} "" {{- end }}
   nodeMetricsPort: 9191
   registry: docker.io
   typhaMetricsPort: 9093
@@ -45,7 +45,10 @@ installation:
 nodeSelector:
   kubernetes.io/os: linux
 # Custom annotations for the tigera/operator pod.
-podAnnotations: {}
+podAnnotations:
+{{- range $key, $value := $.Annotations }}
+  {{ $key }}: {{ $value }}
+{{- end }}
 # Custom labels for the tigera/operator pod.
 podLabels: {}
 # Resource requests and limits for the tigera/operator pod.


### PR DESCRIPTION
**AKS** ✅

kube-system    coredns    {"emptyDir":{},"name":"tmp"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=kube-dns
                    kubernetes.azure.com/managedby=aks
                    kubernetes.io/cluster-service=true
                    version=v20
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
  ```
kube-system    metrics-server    {"emptyDir":{},"name":"tmp-dir"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=metrics-server
                    kubernetes.azure.com/managedby=aks
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
```
tigera-operator    tigera-operator    {"hostPath":{"path":"/var/lib/calico","type":""},"name":"var-lib-calico"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=tigera-operator
                    kubernetes.azure.com/managedby=aks
                    name=tigera-operator
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: var-lib-calico
```

**Azure VMs** ✅
  
kube-system    cloud-controller-manager    {"hostPath":{"path":"/etc/kubernetes","type":""},"name":"etc-kubernetes"} {"hostPath":{"path":"/etc/ssl","type":""},"name":"ssl-mount"} {"hostPath":{"path":"/var/lib/waagent/ManagedIdentity-Settings","type":""},"name":"msi"} 🆗
```bash
Pod Template:
  Labels:           component=cloud-controller-manager
                    tier=control-plane
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: etc-kubernetes,ssl-mount,msi
```
kube-system    csi-azuredisk-controller    {"hostPath":{"path":"/etc/kubernetes/","type":"DirectoryOrCreate"},"name":"azure-cred"} 🆗
kube-system    csi-azuredisk-controller    {"emptyDir":{},"name":"socket-dir"} 🆗
```bash
Pod Template:
  Labels:           app=csi-azuredisk-controller
                    app.kubernetes.io/instance=azuredisk-csi-driver
                    app.kubernetes.io/managed-by=Helm
                    app.kubernetes.io/name=azuredisk-csi-driver
                    app.kubernetes.io/version=v1.28.3
                    helm.sh/chart=azuredisk-csi-driver-v1.28.3
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir,azure-cred
```
kube-system    csi-azurefile-controller    {"hostPath":{"path":"/etc/kubernetes/","type":"DirectoryOrCreate"},"name":"azure-cred"} 🆗
kube-system    csi-azurefile-controller    {"emptyDir":{},"name":"socket-dir"} 🆗
```bash
Pod Template:
  Labels:           app=csi-azurefile-controller
                    app.kubernetes.io/component=csi-driver
                    app.kubernetes.io/instance=azurefile-csi-driver
                    app.kubernetes.io/managed-by=Helm
                    app.kubernetes.io/name=azurefile-csi-driver
                    app.kubernetes.io/part-of=azurefile-csi-driver
                    app.kubernetes.io/version=v1.28.3
                    helm.sh/chart=azurefile-csi-driver-v1.28.3
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir,azure-cred
```
tigera-operator    tigera-operator    {"hostPath":{"path":"/var/lib/calico","type":""},"name":"var-lib-calico"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=tigera-operator
                    name=tigera-operator
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: var-lib-calico
```

**EKS** ✅

tigera-operator    tigera-operator    {"hostPath":{"path":"/var/lib/calico","type":""},"name":"var-lib-calico"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=tigera-operator
                    name=tigera-operator
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: var-lib-calico
```
kube-system    coredns    {"emptyDir":{},"name":"tmp"} 🆗
```bash
Pod Template:
  Labels:           eks.amazonaws.com/component=coredns
                    k8s-app=kube-dns
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
                    eks.amazonaws.com/compute-type: ec2
```
kube-system    ebs-csi-controller    {"emptyDir":{},"name":"socket-dir" 🆗
```bash
Pod Template:
  Labels:           app=ebs-csi-controller
                    app.kubernetes.io/component=csi-driver
                    app.kubernetes.io/managed-by=EKS
                    app.kubernetes.io/name=aws-ebs-csi-driver
                    app.kubernetes.io/version=1.19.0
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
```

**AWS VMs** ✅
  
kube-system    ebs-csi-controller    {"emptyDir":{},"name":"socket-dir"} 🆗 
```bash
Pod Template:
  Labels:           app=ebs-csi-controller
                    app.kubernetes.io/component=csi-driver
                    app.kubernetes.io/instance=aws-ebs-csi-driver
                    app.kubernetes.io/managed-by=Helm
                    app.kubernetes.io/name=aws-ebs-csi-driver
                    app.kubernetes.io/version=1.20.0
                    helm.sh/chart=aws-ebs-csi-driver-2.20.0
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
```
tigera-operator    tigera-operator    {"hostPath":{"path":"/var/lib/calico","type":""},"name":"var-lib-calico"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=tigera-operator
                    name=tigera-operator
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: var-lib-calico
```

**GCP** ✅
 
tigera-operator    tigera-operator    {"hostPath":{"path":"/var/lib/calico","type":""},"name":"var-lib-calico"} 🆗
```bash
Pod Template:
  Labels:           k8s-app=tigera-operator
                    name=tigera-operator
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: var-lib-calico
  ```
kube-system    csi-gce-pd-controller    {"emptyDir":{},"name":"socket-dir"} 🆗
```bash
Pod Template:
  Labels:           app=gcp-compute-persistent-disk-csi-driver
  Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
```