### PR TITLE
Improve retrys & remove golang warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.17.0-0.4.0 (upcoming)
+## 0.17.0-0.5.0 (upcoming)
 
-* Upcoming changelog
+* Improve command execution retrys
 
 ## 0.17.0-0.4.0 (2024-02-22)
 

--- a/bin/images/aws/imagenes-eks-distro.txt
+++ b/bin/images/aws/imagenes-eks-distro.txt
@@ -3,3 +3,4 @@ public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.8.0-eks-1-27-3
 public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-27-3
 public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.8.0-eks-1-27-3
 public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-27-3
+public.ecr.aws/eks/aws-load-balancer-controller:v2.6.2

--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -351,7 +351,7 @@ func (b *AWSBuilder) postInstallPhase(n nodes.Node, k string) error {
 	c := "kubectl --kubeconfig " + kubeconfigPath + " get pdb " + coreDNSPDBName + " -n kube-system"
 	_, err := commons.ExecuteCommand(n, c, 5)
 	if err != nil {
-		err = installCorednsPdb(n, k)
+		err = installCorednsPdb(n)
 		if err != nil {
 			return errors.Wrap(err, "failed to add core dns PDB")
 		}

--- a/pkg/cluster/internal/create/actions/createworker/azure.go
+++ b/pkg/cluster/internal/create/actions/createworker/azure.go
@@ -352,7 +352,7 @@ func (b *AzureBuilder) postInstallPhase(n nodes.Node, k string) error {
 	c := "kubectl --kubeconfig " + kubeconfigPath + " get pdb " + coreDNSPDBName + " -n kube-system"
 	_, err := commons.ExecuteCommand(n, c, 5)
 	if err != nil {
-		err = installCorednsPdb(n, k)
+		err = installCorednsPdb(n)
 		if err != nil {
 			return errors.Wrap(err, "failed to add core dns PDB")
 		}

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -377,7 +377,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		}
 
 		c = "kubectl -n " + capiClustersNamespace + " get cluster " + a.keosCluster.Metadata.Name
-		_, err = commons.ExecuteCommand(n, c, 15)
+		_, err = commons.ExecuteCommand(n, c, 45)
 		if err != nil {
 			return errors.Wrap(err, "failed to wait for cluster")
 		}
@@ -714,7 +714,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			ctx.Status.Start("Customizing CoreDNS configuration 🪡")
 			defer ctx.Status.End(false)
 
-			err = customCoreDNS(n, kubeconfigPath, a.keosCluster)
+			err = customCoreDNS(n, a.keosCluster)
 			if err != nil {
 				return errors.Wrap(err, "failed to customized CoreDNS configuration")
 			}
@@ -855,7 +855,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 	ctx.Status.Start("Generating the KEOS descriptor 📝")
 	defer ctx.Status.End(false)
 
-	err = createKEOSDescriptor(a.keosCluster, scName, a.clusterCredentials)
+	err = createKEOSDescriptor(a.keosCluster, scName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/internal/create/actions/createworker/gcp.go
+++ b/pkg/cluster/internal/create/actions/createworker/gcp.go
@@ -258,7 +258,7 @@ func (b *GCPBuilder) postInstallPhase(n nodes.Node, k string) error {
 	c := "kubectl --kubeconfig " + kubeconfigPath + " get pdb " + coreDNSPDBName + " -n kube-system"
 	_, err := commons.ExecuteCommand(n, c, 5)
 	if err != nil {
-		err = installCorednsPdb(n, k)
+		err = installCorednsPdb(n)
 		if err != nil {
 			return errors.Wrap(err, "failed to add core dns PDB")
 		}

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -90,7 +90,7 @@ type EFSConfig struct {
 	Permissions string `yaml:"permissions"`
 }
 
-func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string, creds commons.ClusterCredentials) error {
+func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) error {
 
 	var keosDescriptor KEOSDescriptor
 	var err error

--- a/pkg/commons/utils.go
+++ b/pkg/commons/utils.go
@@ -246,20 +246,24 @@ func ExecuteCommand(n nodes.Node, command string, timeout int, envVars ...[]stri
 	if len(envVars) > 0 {
 		cmd.SetEnv(envVars[0]...)
 	}
+	retryConditions := []string{"dial tcp: lookup", "NotFound", "timed out waiting"}
+	provisionCommands := strings.Contains(command, "kubectl") || strings.Contains(command, "helm") || strings.Contains(command, "clusterctl")
 	for i := 0; i < 3; i++ {
 		raw = bytes.Buffer{}
 		err = cmd.SetStdout(&raw).SetStderr(&raw).Run()
-		dialLookupErrorPresent := strings.Contains(raw.String(), "dial tcp: lookup")
-		notFoundErrorPresent := strings.Contains(raw.String(), "NotFound")
-		provisionCommands := strings.Contains(command, "kubectl") || strings.Contains(command, "helm")
-
-		if err == nil || !provisionCommands || !(provisionCommands && (dialLookupErrorPresent || notFoundErrorPresent)) {
+		retry := false
+		for _, condition := range retryConditions {
+			if strings.Contains(raw.String(), condition) {
+				retry = true
+			}
+		}
+		if err == nil || !(provisionCommands && retry) {
 			break
 		}
 		time.Sleep(time.Duration(timeout) * time.Second)
 	}
-	if strings.Contains(raw.String(), "Error:") {
-		return "", errors.Wrap(err, "Command Output: "+raw.String())
+	if strings.Contains(raw.String(), "Error:") || strings.Contains(raw.String(), "Error from server") {
+		return "", errors.New("Command Output: " + raw.String())
 	}
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Improve retries & remove golang warnings

## Description
- Improve execution commands retries.
- Remove golang warnings.
- Clean error output
- Increase get cluster timeout
- Refactor wait for calico namespace

## How to Test
Compile a binary with this branch and create a cluster in any provider.

## Additional Information
- Cherry pick from [PR514](https://github.com/Stratio/kind/pull/514)

## Checklist
- [X] [PR desc] List any pull-request related to this change.
- [X] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [X] [Changelog] Add the changes to CHANGELOG.md.    
- [X] [Docs] Add the changes to the documentation.
- [X] [QA] Add the new unit tests according to the changes.