### PR TITLE
[CLOUD-45] Asegurar replicas de coredns en distintos nodos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
 # Changelog
 
-## 0.17.0-0.5.0 (upcoming)
+## 0.17.0-0.6.0 (upcoming)
+
+* [Core] Ensure CoreDNS replicas are assigned to different nodes
+
+## 0.17.0-0.5.2 (2024-06-25)
+
+* [Core] Delete cluster autoscaler references in the upgrade script
+
+## 0.17.0-0.5.1 (2024-06-21)
+
+* [Core] Ensure that keoscluster exists in the upgrade script
+* [Core] Fix clusterctl move retries
+
+## 0.17.0-0.5.0 (2024-06-10)
 
 * [Core] Update runc golang module to fix GHSA-xr7r-f8xq-vfvv
 * [Core] Improve command execution retries
 * [Core] Support k8s v1.28
+* [Core] Fix panic when keos_version is not defined
+* [Core] Script the upgrade
 
 ## 0.17.0-0.4.0 (2024-02-22)
 
@@ -97,3 +112,4 @@
 * Add clusterAPI capabilities for EKS
 
 ## Previous development
+

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -593,7 +593,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 				return errors.Wrap(err, "failed to patch aws-node clusterrole")
 			}
 		}
-		
+
 		ctx.Status.Start("Installing StorageClass in workload cluster 💾")
 		defer ctx.Status.End(false)
 

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -545,14 +545,6 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 		ctx.Status.End(true) // End Preparing nodes in workload cluster
 
-		// Ensure CoreDNS replicas are assigned to different nodes
-		// once more than 2 control planes or workers are running
-		c = "kubectl --kubeconfig " + kubeconfigPath + " -n kube-system rollout restart deployment coredns"
-		_, err = commons.ExecuteCommand(n, c, 5)
-		if err != nil {
-			return errors.Wrap(err, "failed to restart coredns deployment")
-		}
-
 		if awsEKSEnabled {
                         c = "kubectl --kubeconfig " + kubeconfigPath + " get clusterrole aws-node -o jsonpath='{.rules}'"
                         awsnoderules, err := commons.ExecuteCommand(n, c, 5)
@@ -574,6 +566,14 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
                         if err != nil {
                                 return errors.Wrap(err, "failed to patch aws-node clusterrole")
                         }
+                }
+
+                // Ensure CoreDNS replicas are assigned to different nodes
+                // once more than 2 control planes or workers are running
+                c = "kubectl --kubeconfig " + kubeconfigPath + " -n kube-system rollout restart deployment coredns"
+                _, err = commons.ExecuteCommand(n, c, 5)
+                if err != nil {
+                        return errors.Wrap(err, "failed to restart coredns deployment")
                 }
 
 		// Wait for CoreDNS deployment to be ready


### PR DESCRIPTION
## Description

Ensure CoreDNS replicas are assigned to different nodes

## Related Pull Requests

- https://stratio.atlassian.net/browse/CLOUD-45

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [X] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [X] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).