### PR TITLE
[PLT-563] [GKE] Problemas con Autoescalado

### DIFF
--- a/pkg/cluster/internal/providers/docker/stratio/Dockerfile
+++ b/pkg/cluster/internal/providers/docker/stratio/Dockerfile
@@ -29,6 +29,10 @@ ENV CAPA=v2.2.1
 ENV CAPG=v1.6.1
 ENV CAPZ=v1.11.4
 
+# Modify GCP infrastructure components
+ENV SEARCH_STRING="machinepools\/status"
+ENV FILE=${CAPI_REPO}/infrastructure-gcp/${CAPG}/infrastructure-components.yaml
+
 # Install vim
 RUN apt-get update && apt-get install -y \
   vim python3-pip git \
@@ -95,3 +99,6 @@ RUN curl -L  https://github.com/kubernetes-sigs/cluster-api/releases/download/${
     && curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL}/metadata.yaml -o ${CAPI_REPO}/cluster-api/${CLUSTERCTL}/metadata.yaml \
     && cp ${CAPI_REPO}/cluster-api/${CLUSTERCTL}/metadata.yaml ${CAPI_REPO}/bootstrap-kubeadm/${CLUSTERCTL}/metadata.yaml \
     && cp ${CAPI_REPO}/cluster-api/${CLUSTERCTL}/metadata.yaml ${CAPI_REPO}/control-plane-kubeadm/${CLUSTERCTL}/metadata.yaml
+
+# Run the sed command to modify the file
+RUN sed -i "/$SEARCH_STRING/{n;N;N;N;s/.*/  verbs:\n  - get\n  - list\n  - watch\n  - update\n  - patch/}" $FILE


### PR DESCRIPTION
## Description

Al autoescalar un grupo de nodos, las instancias se crean y se agregan al cluster de K8s como nodos en Ready, pero no se refleja el cambio de replicas en el "spec.replicas" de lo "machinepools".

Solución propuesta:

Modificar los permisos necesarios en el ficher infrastructure-components.yaml que nos descargamos del provider para poder añadir los permisos necesarios en el role del capg-manager, con objetivo de poder modificar los machinepools.

## Related Pull Requests

- PR: https://github.com/Stratio/cluster-api-provider-gcp/pull/8

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[PLT-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [X] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [X] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

## Test Done:
- Revisión del fichero infrastructure-components.yaml (avoid-creation)
- Revisión de los permisos añadidos en el role en el workload cluster

[PLT-99]: https://stratio.atlassian.net/browse/PLT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ