### PR TITLE
[PLT-327] [GKE] After creating a GKE cluster, it takes 20 minutes for its status to be READY

### DIFF
--- a/pkg/cluster/internal/providers/docker/stratio/Dockerfile
+++ b/pkg/cluster/internal/providers/docker/stratio/Dockerfile
@@ -95,3 +95,6 @@ RUN curl -L  https://github.com/kubernetes-sigs/cluster-api/releases/download/${
     && curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL}/metadata.yaml -o ${CAPI_REPO}/cluster-api/${CLUSTERCTL}/metadata.yaml \
     && cp ${CAPI_REPO}/cluster-api/${CLUSTERCTL}/metadata.yaml ${CAPI_REPO}/bootstrap-kubeadm/${CLUSTERCTL}/metadata.yaml \
     && cp ${CAPI_REPO}/cluster-api/${CLUSTERCTL}/metadata.yaml ${CAPI_REPO}/control-plane-kubeadm/${CLUSTERCTL}/metadata.yaml
+
+# Modify GCP infrastructure components
+RUN sed -i "/insecure-diagnostics/a \        - --sync-period=2m" ${CAPI_REPO}/infrastructure-gcp/${CAPG}/infrastructure-components.yaml


### PR DESCRIPTION
## Description

Tras desplegar un cluster en GKE sin ninguna configuración en particular el status del cluster-opertor tarda ~20 minutos en pasar a READY.

Solución propuesta:

Reconfigurar el sync-period en el controller-manager de CAPG.

## Related Pull Requests

PR: None

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [X] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

## Tests Done:
- Check new config on capg deployment (avoid-creation)
- Check cluster-operator gets READY on workload cluster in a few minutes