### PR TITLE
[FIX][0.6] Fix keoscluster-registries creation workload cluster

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -506,6 +506,18 @@ func (p *Provider) deployClusterOperator(n nodes.Node, privateParams PrivatePara
 		}
 	}
 
+	if clusterCredentials.DockerRegistriesCredentials != nil && firstInstallation {
+		jsonDockerRegistriesCredentials, err := json.Marshal(clusterCredentials.DockerRegistriesCredentials)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal docker registries credentials")
+		}
+		c = "kubectl -n kube-system create secret generic keoscluster-registries --from-literal=credentials='" + string(jsonDockerRegistriesCredentials) + "'"
+		_, err = commons.ExecuteCommand(n, c, 5, 3)
+		if err != nil {
+			return errors.Wrap(err, "failed to create keoscluster-registries secret")
+		}
+	}
+
 	if kubeconfigPath == "" {
 		// Clean keoscluster file
 		keosCluster.Spec.Credentials = commons.Credentials{}
@@ -561,18 +573,6 @@ func (p *Provider) deployClusterOperator(n nodes.Node, privateParams PrivatePara
 			_, err = commons.ExecuteCommand(n, c, 5, 3)
 			if err != nil {
 				return errors.Wrap(err, "failed to pull cluster-operator helm chart")
-			}
-		}
-		// Create the docker registries credentials secret for keoscluster-controller-manager
-		if clusterCredentials.DockerRegistriesCredentials != nil && firstInstallation {
-			jsonDockerRegistriesCredentials, err := json.Marshal(clusterCredentials.DockerRegistriesCredentials)
-			if err != nil {
-				return errors.Wrap(err, "failed to marshal docker registries credentials")
-			}
-			c = "kubectl -n kube-system create secret generic keoscluster-registries --from-literal=credentials='" + string(jsonDockerRegistriesCredentials) + "'"
-			_, err = commons.ExecuteCommand(n, c, 5, 3)
-			if err != nil {
-				return errors.Wrap(err, "failed to create keoscluster-registries secret")
 			}
 		}
 		// Deploy cluster-operator chart

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -506,12 +506,16 @@ func (p *Provider) deployClusterOperator(n nodes.Node, privateParams PrivatePara
 		}
 	}
 
+	// Create the docker registries credentials secret for keoscluster-controller-manager
 	if clusterCredentials.DockerRegistriesCredentials != nil && firstInstallation {
 		jsonDockerRegistriesCredentials, err := json.Marshal(clusterCredentials.DockerRegistriesCredentials)
 		if err != nil {
 			return errors.Wrap(err, "failed to marshal docker registries credentials")
 		}
 		c = "kubectl -n kube-system create secret generic keoscluster-registries --from-literal=credentials='" + string(jsonDockerRegistriesCredentials) + "'"
+		if kubeconfigPath != "" {
+			c = c + " --kubeconfig " + kubeconfigPath
+		}
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
 			return errors.Wrap(err, "failed to create keoscluster-registries secret")


### PR DESCRIPTION
## Description

fix keoscluster-registries creation workload cluster
```bash
2024-09-24T15:14:45Z    ERROR   could not get docker registries credentials: secrets "keoscluster-registries" not found {"controller": "keoscluster", "controllerGroup": "installer.stratio.com", "controllerKind": "
KeosCluster", "KeosCluster": {"name":"janr-aws","namespace":"cluster-janr-aws"}, "namespace": "cluster-janr-aws", "name": "janr-aws", "reconcileID": "4e185766-01b2-4ecd-9ca0-44b1b4d15a58", "error": "could not get
docker registries credentials: secrets \"keoscluster-registries\" not found"}
```

## Related Pull Requests

N/A

## Pull Request Checklist:

- [ ] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [x] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [x] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

