### PR TITLE
[PLT-929] Removed calico installation as policy manager by helm chart in GKE

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -758,29 +758,29 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 		// After calico is installed and network policies are applied, patch the tigera-operator clusterrole to allow resourcequotas creation
 
-		if gcpGKEEnabled {
-			c = "kubectl --kubeconfig " + kubeconfigPath + " get clusterrole tigera-operator -o jsonpath='{.rules}'"
-			tigerarules, err := commons.ExecuteCommand(n, c, 5)
-			if err != nil {
-				return errors.Wrap(err, "failed to get tigera-operator clusterrole rules")
-			}
-			var rules []json.RawMessage
-			err = json.Unmarshal([]byte(tigerarules), &rules)
-			if err != nil {
-				return errors.Wrap(err, "failed to parse tigera-operator clusterrole rules")
-			}
-			// create, delete
-			rules = append(rules, json.RawMessage(`{"apiGroups": [""],"resources": ["resourcequotas"],"verbs": ["create"]}`))
-			newtigerarules, err := json.Marshal(rules)
-			if err != nil {
-				return errors.Wrap(err, "failed to marshal tigera-operator clusterrole rules")
-			}
-			c = "kubectl --kubeconfig " + kubeconfigPath + " patch clusterrole tigera-operator -p '{\"rules\": " + string(newtigerarules) + "}'"
-			_, err = commons.ExecuteCommand(n, c, 5)
-			if err != nil {
-				return errors.Wrap(err, "failed to patch tigera-operator clusterrole")
-			}
-		}
+		// if gcpGKEEnabled {
+		// 	c = "kubectl --kubeconfig " + kubeconfigPath + " get clusterrole tigera-operator -o jsonpath='{.rules}'"
+		// 	tigerarules, err := commons.ExecuteCommand(n, c, 5)
+		// 	if err != nil {
+		// 		return errors.Wrap(err, "failed to get tigera-operator clusterrole rules")
+		// 	}
+		// 	var rules []json.RawMessage
+		// 	err = json.Unmarshal([]byte(tigerarules), &rules)
+		// 	if err != nil {
+		// 		return errors.Wrap(err, "failed to parse tigera-operator clusterrole rules")
+		// 	}
+		// 	// create, delete
+		// 	rules = append(rules, json.RawMessage(`{"apiGroups": [""],"resources": ["resourcequotas"],"verbs": ["create"]}`))
+		// 	newtigerarules, err := json.Marshal(rules)
+		// 	if err != nil {
+		// 		return errors.Wrap(err, "failed to marshal tigera-operator clusterrole rules")
+		// 	}
+		// 	c = "kubectl --kubeconfig " + kubeconfigPath + " patch clusterrole tigera-operator -p '{\"rules\": " + string(newtigerarules) + "}'"
+		// 	_, err = commons.ExecuteCommand(n, c, 5)
+		// 	if err != nil {
+		// 		return errors.Wrap(err, "failed to patch tigera-operator clusterrole")
+		// 	}
+		// }
 
 		if a.keosCluster.Spec.DeployAutoscaler && !isMachinePool {
 			ctx.Status.Start("Installing cluster-autoscaler in workload cluster 🗚")

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -695,7 +695,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		ctx.Status.End(true) // End Enabling workload cluster's self-healing
 
 		// Use Calico as network policy engine in managed systems
-		if provider.capxProvider != "azure" {
+		if provider.capxProvider == "aws" {
 			ctx.Status.Start("Configuring Network Policy Engine in workload cluster 🚧")
 			defer ctx.Status.End(false)
 

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -695,18 +695,29 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		ctx.Status.End(true) // End Enabling workload cluster's self-healing
 
 		// Use Calico as network policy engine in managed systems
-		if provider.capxProvider == "aws" {
+		if provider.capxProvider != "azure" {
+
 			ctx.Status.Start("Configuring Network Policy Engine in workload cluster 🚧")
 			defer ctx.Status.End(false)
 
 			// Use Calico as network policy engine in managed systems
-			if a.keosCluster.Spec.ControlPlane.Managed {
+			if awsEKSEnabled {
 
 				err = installCalico(n, kubeconfigPath, privateParams, allowCommonEgressNetPolPath, true)
 				if err != nil {
 					return errors.Wrap(err, "failed to install Network Policy Engine in workload cluster")
 				}
 			}
+
+			// if gcpGKEEnabled {
+
+			// 	// Create calico metrics services
+			// 	cmd := n.Command("kubectl", "--kubeconfig", kubeconfigPath, "-n", "kube-system", "apply", "-f", "-")
+			// 	if err = cmd.SetStdin(strings.NewReader(calicoMetrics)).Run(); err != nil {
+			// 		return errors.Wrap(err, "failed to create calico metrics services")
+			// 	}
+
+			// }
 
 			// Create the allow and deny (global) network policy file in the container
 			denyallEgressIMDSGNetPolPath := "/kind/deny-all-egress-imds_gnetpol.yaml"

--- a/pkg/cluster/internal/create/actions/createworker/gcp.go
+++ b/pkg/cluster/internal/create/actions/createworker/gcp.go
@@ -56,7 +56,7 @@ func newGCPBuilder() *GCPBuilder {
 func (b *GCPBuilder) setCapx(managed bool) {
 	b.capxProvider = "gcp"
 	b.capxVersion = "v1.6.1"
-	b.capxImageVersion = "1.6.1-0.2.0-221789b"
+	b.capxImageVersion = "1.6.1-0.2.0-9583120"
 	b.capxName = "capg"
 	b.capxManaged = managed
 	b.csiNamespace = "kube-system"

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -362,21 +362,8 @@ func (p *Provider) deployClusterOperator(n nodes.Node, privateParams PrivatePara
 		if keosCluster.Spec.InfraProvider != "aws" || (keosCluster.Spec.InfraProvider == "aws" && !keosCluster.Spec.ControlPlane.Managed) {
 			keosCluster.Spec.ControlPlane.AWS = commons.AWSCP{}
 		}
-		if keosCluster.Spec.InfraProvider == "gcp" && keosCluster.Spec.ControlPlane.Managed {
-			// Ensure ClusterNetwork is initialized
-			if keosCluster.Spec.ControlPlane.ClusterNetwork == nil {
-				//	fmt.Println("Initializing ClusterNetwork")
-				keosCluster.Spec.ControlPlane.ClusterNetwork = &commons.ClusterNetwork{}
-			}
-
-			// Ensure PrivateCluster is initialized
-			if keosCluster.Spec.ControlPlane.ClusterNetwork.PrivateCluster == nil {
-				//	fmt.Println("Initializing PrivateCluster")
-				keosCluster.Spec.ControlPlane.ClusterNetwork.PrivateCluster = &commons.PrivateCluster{}
-			}
-
-			keosCluster.Spec.ControlPlane.ClusterNetwork.PrivateCluster.EnablePrivateNodes = keosCluster.Spec.ControlPlane.ClusterNetwork.PrivateCluster.EnablePrivateNodes
-			keosCluster.Spec.ControlPlane.ClusterNetwork.PrivateCluster.ControlPlaneCidrBlock = keosCluster.Spec.ControlPlane.ClusterNetwork.PrivateCluster.ControlPlaneCidrBlock
+		if !(keosCluster.Spec.InfraProvider == "gcp" && keosCluster.Spec.ControlPlane.Managed) {
+			keosCluster.Spec.ControlPlane.Gcp = commons.GCPCP{}
 		}
 
 		if keosCluster.Spec.ControlPlane.Managed {

--- a/pkg/cluster/internal/providers/docker/stratio/Dockerfile
+++ b/pkg/cluster/internal/providers/docker/stratio/Dockerfile
@@ -28,7 +28,7 @@ ENV CAPI_REPO=/root/.cluster-api/local-repository
 ENV CAPA=v2.2.1
 ENV CAPG=v1.6.1
 ENV CAPZ=v1.11.4
-ENV CAPG_FORK_URL="https://github.com/Stratio/cluster-api-provider-gcp/releases/download/1.6.1-0.2.0-M2/"
+ENV CAPG_FORK_URL="https://github.com/Stratio/cluster-api-provider-gcp/releases/download/1.6.1-0.2.0-9583120/"
 
 # Install vim
 RUN apt-get update && apt-get install -y \

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -119,8 +119,8 @@ type KeosSpec struct {
 		Tags            []map[string]string `yaml:"tags,omitempty"`
 		AWS             AWSCP               `yaml:"aws,omitempty"`
 		Azure           AzureCP             `yaml:"azure,omitempty"`
+		Gcp             GCPCP               `yaml:"gcp,omitempty"`
 		ExtraVolumes    []ExtraVolume       `yaml:"extra_volumes,omitempty" validate:"dive"`
-		ClusterNetwork  *ClusterNetwork     `yaml:"cluster_network,omitempty"`
 	} `yaml:"control_plane"`
 
 	WorkerNodes WorkerNodes `yaml:"worker_nodes" validate:"required,dive"`
@@ -128,14 +128,37 @@ type KeosSpec struct {
 	ClusterConfigRef ClusterConfigRef `yaml:"cluster_config_ref,omitempty" validate:"dive"`
 }
 
+type GCPCP struct {
+	ClusterNetwork                 ClusterNetwork                 `yaml:"cluster_network,omitempty"`
+	MasterAuthorizedNetworksConfig MasterAuthorizedNetworksConfig `yaml:"master_authorized_networks_config,omitempty"`
+}
+
 type ClusterNetwork struct {
-	PrivateCluster *PrivateCluster `yaml:"private_cluster,omitempty"`
+	PrivateCluster PrivateCluster `yaml:"private_cluster,omitempty"`
 }
 
 type PrivateCluster struct {
 	// +kubebuilder:default=true
-	EnablePrivateNodes    bool   `yaml:"enable_private_nodes,omitempty"`
+	EnablePrivateEndpoint bool `yaml:"enable_private_endpoint,omitempty"`
+	// +kubebuilder:default=true
+	EnablePrivateNodes bool `yaml:"enable_private_nodes,omitempty"`
+	// +kubebuilder:validation:Pattern=`^(10\.\d{1,3}\.\d{1,3}\.\d{1,3}\/[0-9]{1,2})$|^(172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}\/[0-9]{1,2})$|^(192\.168\.\d{1,3}\.\d{1,3}\/[0-9]{1,2})$`
 	ControlPlaneCidrBlock string `yaml:"control_plane_cidr_block,omitempty"`
+}
+
+// MasterAuthorizedNetworksConfig represents configuration options for master authorized networks feature of the GKE cluster.
+type MasterAuthorizedNetworksConfig struct {
+	CIDRBlocks []CIDRBlock `yaml:"cidr_blocks,omitempty"`
+	// +kubebuilder:default=false
+	GCPPublicCIDRsAccessEnabled *bool `yaml:"gcp_public_cidrs_access_enabled,omitempty"`
+}
+
+type CIDRBlock struct {
+	// +kubebuilder:validation:Pattern=`^(10\.\d{1,3}\.\d{1,3}\.\d{1,3}\/[0-9]{1,2})$|^(172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}\/[0-9]{1,2})$|^(192\.168\.\d{1,3}\.\d{1,3}\/[0-9]{1,2})$`
+	CIDRBlock string `yaml:"cidr_block"`
+
+	// +kubebuilder:validation:Optional
+	DisplayName string `yaml:"display_name,omitempty"`
 }
 
 type Keos struct {
@@ -393,6 +416,12 @@ func (s KeosSpec) Init() KeosSpec {
 	s.ControlPlane.AWS.Logging.Authenticator = false
 	s.ControlPlane.AWS.Logging.ControllerManager = false
 	s.ControlPlane.AWS.Logging.Scheduler = false
+
+	// GKE
+
+	s.ControlPlane.Gcp.ClusterNetwork.PrivateCluster.EnablePrivateEndpoint = true
+	s.ControlPlane.Gcp.ClusterNetwork.PrivateCluster.EnablePrivateNodes = true
+	s.ControlPlane.Gcp.MasterAuthorizedNetworksConfig.GCPPublicCIDRsAccessEnabled = ToPtr[bool](false)
 
 	// Helm
 	s.HelmRepository.AuthRequired = false


### PR DESCRIPTION
## Description

Hasta este momento se instalaba en clusters gestionados de EKS y GKE calico como motor de políticas de red de forma manual, mediante un chart de helm y delegando la parte de CNI al propio addon del cloud provider. Se comprobó que esta forma de instalación no funcionaba para GKE y en caso de querer utilizar calico como motor de politicas de red debía ser instalado como addon de GKE.

Se ha eliminado la comprobación que permitía la instalación en GKE del chart de tigera-operator y se ha añadido a la sección de la networkPolicy del template de GKE

## Related Pull Requests

https://github.com/Stratio/cluster-operator/pull/232

## Pull Request Checklist:

- [ ] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [ ] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

