### PR TITLE
[PLT-923] Remove path /stratio from container image reference for kub…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [PLT-917] Replace coredns yaml files with a single coredns tmpl file
 * [PLT-929] Removed calico installation as policy manager by helm chart in GKE
 * [PLT-911] Support for Disable External Endpoint in GKE
+* [PLT-923] Remove path /stratio from container image reference for kube-rbac-proxy image
 
 ## 0.17.0-0.5.3 (2024-09-24)
 

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -593,7 +593,7 @@ func (p *Provider) deployClusterOperator(n nodes.Node, privateParams PrivatePara
 			c += " --set app.containers.controllerManager.image.tag=" + clusterOperatorImage
 		}
 		if privateParams.Private {
-			c += " --set app.containers.kubeRbacProxy.image=" + keosRegistry.url + "/stratio/kube-rbac-proxy:v0.13.1"
+			c += " --set app.containers.kubeRbacProxy.image=" + keosRegistry.url + "/kube-rbac-proxy:v0.13.1"
 		}
 		if keosCluster.Spec.InfraProvider == "azure" {
 			c += " --set secrets.azure.clientIDBase64=" + strings.Split(p.capxEnvVars[1], "AZURE_CLIENT_ID_B64=")[1] +


### PR DESCRIPTION
…e-rbac-proxy image


## Description

Delete path /stratio from image reference for kube-rbac-proxy
`<container_registry>/stratio/kube-rbac-proxy:v0.13.1`

Now, image reference would be
`<container_registry>/kube-rbac-proxy:v0.13.1`