### PR TITLE
[PLT-1654] Fix AWS ClusterRole patch during cloud-provisioner upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.17.0-0.5.8 (upcoming)
+
+* [PLT-1654] Fix AWS ClusterRole patch during cloud-provisioner upgrade
 
 ## 0.17.0-0.5.7 (2024-12-09)
 


### PR DESCRIPTION
Para validarlo de forma unitaria se ha hecho lo siguiente:

- Crear el `ClusterRole` `aws-node` con la siguiente definición:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: aws-node
rules:
- apiGroups:
  - crd.k8s.amazonaws.com
  resources:
  - eniconfigs
  verbs:
  - list
  - watch
  - get
- apiGroups:
  - ""
  resources:
  - namespaces
  verbs:
  - list
  - watch
  - get
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - list
  - watch
  - get
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - list
  - watch
  - get
  - update
- apiGroups:
  - extensions
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - ""
  - events.k8s.io
  resources:
  - events
  verbs:
  - create
  - patch
  - list
```

- Ejecutar el siguiente script para replicar el caso de uso de las modificaciones en el recurso `ClusterRole` `aws-node`:

```python
import json
import subprocess
import sys

kubectl = "kubectl"

def patch_clusterrole_aws_node(dry_run):
    aws_node_clusterrole_name = "aws-node"
    print("[INFO] Modifying aws-node ClusterRole:", end =" ", flush=True)
    if not dry_run:
        get_clusterrole_command = kubectl + " get clusterrole -o json " + aws_node_clusterrole_name + " | jq -r '.rules'"
        cluster_role_rule = json.loads(execute_command(get_clusterrole_command, False))
        rule_pods_index = next((i for i, rule in enumerate(cluster_role_rule) if 'pods' in rule.get('resources', [])), None)
        if rule_pods_index is not None:
            verbs = cluster_role_rule[rule_pods_index].get('verbs', [])
            if 'patch' not in verbs:
                patch = [
                    {
                        "op": "add",
                        "path": f"/rules/{rule_pods_index}/verbs/-",
                        "value": "patch"
                    }
                ]
                patch_clusterrole_command = kubectl + " patch clusterrole " + aws_node_clusterrole_name + " --type=json -p='" + json.dumps(patch) + "'"
                execute_command(patch_clusterrole_command, False, False)
        else:
            print("[ERROR] Pods resource not found in the ClusterRole " + aws_node_clusterrole_name)
            sys.exit(1)
    else:
        print("DRY-RUN")

def execute_command(command, dry_run, result = True, max_retries=3, retry_delay=5):
    output = ""
    retries = 0

    while retries < max_retries:
        if dry_run:
            if result:
                print("DRY-RUN")
            return ""  # No output in dry-run mode
        else:
            status, output = subprocess.getstatusoutput(command)
            if status == 0:
                if result:
                    print("OK")
                return output
            else:
                if "Unable to connect to the server: net/http: TLS handshake timeout" in output:
                    retries += 1
                    time.sleep(retry_delay)
                else:
                    print("FAILED")
                    print("[ERROR] " + output)
                    sys.exit(1)

patch_clusterrole_aws_node(False)
```

- Tras esto comprobamos que la ejecución añade el permiso de `patch` sobre la regla que aplica a `pods`:

```bash
$ diff -U 10 aws-node-before-patch.yml aws-node-afer-patch.yml
--- aws-node-orig.yml
+++ aws-node-new.yml
@@ -20,20 +20,21 @@
   - watch
   - get
 - apiGroups:
   - ""
   resources:
   - pods
   verbs:
   - list
   - watch
   - get
+  - patch
 - apiGroups:
   - ""
   resources:
   - nodes
   verbs:
   - list
   - watch
   - get
   - update
 - apiGroups:
```

- También hemos asegurado que el procedimiento es idempotente ejecutando el script varias veces y revisando que el resultado del objeto `ClusterRole` sea el mismo