### PR TITLE
[branch-0.17.0-0.6] antora.yml version update to 0.6

### DIFF
--- a/stratio-docs/en/antora.yml
+++ b/stratio-docs/en/antora.yml
@@ -1,6 +1,6 @@
 name: cloud-provisioner
 title: Stratio Cloud Provisioner
-version: '0.5'
+version: '0.6'
 nav:
 - modules/ROOT/nav.adoc
 start_page: introduction.adoc

--- a/stratio-docs/es/antora.yml
+++ b/stratio-docs/es/antora.yml
@@ -1,6 +1,6 @@
 name: cloud-provisioner
 title: Stratio Cloud Provisioner
-version: '0.5'
+version: '0.6'
 nav:
 - modules/ROOT/nav.adoc
 start_page: introduction.adoc


### PR DESCRIPTION
Esta PR actualiza la versión de documentación recogida en el fichero antora.yml, que por error indica la 0.5 cuando debe ser la 0.6.