### PR TITLE
[PLT-1968] [BUG][upgrade 1.28 a 1.30] Flag --private-registry no accede al chart oci de cert-manager

### DIFF
--- a/scripts/upgrade-provisioner.py
+++ b/scripts/upgrade-provisioner.py
@@ -1389,16 +1389,17 @@ def export_default_values(chart, repo, default_values_file):
     
     try: 
         chart_name, chart_version = chart["chart"].rsplit("-", 1)
-        command = f"{helm} show values --repo {repo} --version {chart_version} {chart_name}> {default_values_file}"
-        if chart['name'] == "cluster-operator":
-            command = f"{helm} show values {repo}/{chart_name} --version {chart['chart_version']} > {default_values_file}"
+        # Fix: Append the chart name to the OCI repository URL
+        if "oci://" in repo:
+            command = f"{helm} show values {repo}/{chart_name} --version {chart_version} > {default_values_file}"
+        else:
+            command = f"{helm} show values --repo {repo} --version {chart_version} {chart_name} > {default_values_file}"
         
         default_values, err = run_command(command)
         return default_values
     except Exception as e:
         raise
-    
-    
+       
 def create_configmap_from_values(configmap_name, namespace, values_file):
     '''Create a ConfigMap from values'''
     


### PR DESCRIPTION
## Description

The issue lies in the way the Helm repository URL and chart name are being combined. The current implementation does not append the chart name correctly to the repository URL.

Now we check for oci or none oci repositories.

## Related Pull Requests

N/A

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

