### PR TITLE
[PLT-2305][EKS] No se crea política en calico-system

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -819,7 +819,7 @@ spec:
 			}
 
 			// Allow egress in calico-system namespace
-			c = "kubectl --kubeconfig " + kubeconfigPath + " -n " + "tigera-operator" + " apply -f " + allowCommonEgressNetPolPath
+			c = "kubectl --kubeconfig " + kubeconfigPath + " -n " + "calico-system" + " apply -f " + allowCommonEgressNetPolPath
 			_, err = commons.ExecuteCommand(n, c, 5, 3)
 			if err != nil {
 				return errors.Wrap(err, "failed to apply tigera-operator egress NetworkPolicy")


### PR DESCRIPTION
## Description

Allow all egress netpol policy on calico-system namespace

## Related Pull Requests

N/A

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

