### PR TITLE
[PLT-2653] Bump cluster-autoscaler version to v1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.17.0-0.8.0 (upcoming)
 
-* [PLT-2124] Bump cluster-autoscaler to v1.32.2 version and its chart version to 9.50.1
+* [PLT-2124] Bump cluster-autoscaler to v1.33.0 version and its chart version to 9.50.1
 * [PLT-2643] Bump aws-load-balancer-controller to v2.13.4
 * [PLT-2656] Bump Tigera Operator version to v3.30.2
 * [PLT-2656] Bump Calico version to v3.30.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0-0.8.0 (upcoming)
 
+* [PLT-2124] Bump cluster-autoscaler to v1.32.2 version and its chart version to 9.50.1
 * [PLT-2643] Bump aws-load-balancer-controller to v2.13.4
 * [PLT-2656] Bump Tigera Operator version to v3.30.2
 * [PLT-2656] Bump Calico version to v3.30.2

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -23,7 +23,7 @@ core:
       cert-manager-controller: v1.18.1
       cert-manager-startupapicheck: v1.18.1
       cert-manager-webhook: v1.18.1
-    cluster-autoscaler: v1.32.0
+    cluster-autoscaler: v1.32.2
     cluster-operator:
       cluster-operator: 0.5.2
       kube-rbac-proxy: v0.15.0
@@ -43,7 +43,7 @@ core:
       kube-scheduler: v1.27.0
   charts:
     cert-manager: v1.18.1
-    cluster-autoscaler: 9.46.6
+    cluster-autoscaler: 9.50.1
     cluster-operator: 0.5.2
     flux: 2.16.4
     tigera-operator: v3.30.2

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -23,7 +23,7 @@ core:
       cert-manager-controller: v1.18.1
       cert-manager-startupapicheck: v1.18.1
       cert-manager-webhook: v1.18.1
-    cluster-autoscaler: v1.32.2
+    cluster-autoscaler: v1.33.0
     cluster-operator:
       cluster-operator: 0.5.2
       kube-rbac-proxy: v0.15.0

--- a/docs/images/commons/imagenes-cluster-autoscaler.txt
+++ b/docs/images/commons/imagenes-cluster-autoscaler.txt
@@ -1,1 +1,1 @@
-registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0
+registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.2

--- a/docs/images/commons/imagenes-cluster-autoscaler.txt
+++ b/docs/images/commons/imagenes-cluster-autoscaler.txt
@@ -1,1 +1,1 @@
-registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.2
+registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.0

--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -118,7 +118,7 @@ var awsCharts = ChartsDictionary{
 		"32": {
 			"managed": {
 				"aws-load-balancer-controller": {Repository: "https://aws.github.io/eks-charts", Version: "1.13.4", Namespace: "kube-system", Pull: false, Reconcile: false},
-				"cluster-autoscaler":           {Repository: "https://kubernetes.github.io/autoscaler", Version: "9.46.6", Namespace: "kube-system", Pull: false, Reconcile: false},
+				"cluster-autoscaler":           {Repository: "https://kubernetes.github.io/autoscaler", Version: "9.50.1", Namespace: "kube-system", Pull: false, Reconcile: false},
 				"tigera-operator":              {Repository: "https://docs.projectcalico.org/charts", Version: "v3.30.2", Namespace: "tigera-operator", Pull: true, Reconcile: true},
 			},
 			"unmanaged": {},

--- a/pkg/cluster/internal/create/actions/createworker/azure.go
+++ b/pkg/cluster/internal/create/actions/createworker/azure.go
@@ -62,7 +62,7 @@ var azureCharts = ChartsDictionary{
 				"azuredisk-csi-driver": {Repository: "https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts", Namespace: "kube-system", Version: "1.31.2", Pull: false, Reconcile: false},
 				"azurefile-csi-driver": {Repository: "https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/charts", Namespace: "kube-system", Version: "1.31.2", Pull: false, Reconcile: false},
 				"cloud-provider-azure": {Repository: "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo", Namespace: "kube-system", Version: "1.32.0", Pull: true, Reconcile: true},
-				"cluster-autoscaler":   {Repository: "https://kubernetes.github.io/autoscaler", Version: "9.46.6", Namespace: "kube-system", Pull: false, Reconcile: false},
+				"cluster-autoscaler":   {Repository: "https://kubernetes.github.io/autoscaler", Version: "9.50.1", Namespace: "kube-system", Pull: false, Reconcile: false},
 				"tigera-operator":      {Repository: "https://docs.projectcalico.org/charts", Version: "v3.30.2", Namespace: "tigera-operator", Pull: true, Reconcile: true},
 			},
 		},

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/32/cluster-autoscaler-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/32/cluster-autoscaler-helm-values.tmpl
@@ -11,5 +11,5 @@ cloudProvider: clusterapi
 
 image:
   repository: {{ if $.Private }}{{ $.KeosRegUrl }}{{ else }}registry.k8s.io{{ end }}/autoscaling/cluster-autoscaler
-  #tag: v1.32.0
+  #tag: v1.32.2
 replicaCount: 2

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/32/cluster-autoscaler-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/32/cluster-autoscaler-helm-values.tmpl
@@ -11,5 +11,5 @@ cloudProvider: clusterapi
 
 image:
   repository: {{ if $.Private }}{{ $.KeosRegUrl }}{{ else }}registry.k8s.io{{ end }}/autoscaling/cluster-autoscaler
-  #tag: v1.32.2
+  #tag: v1.33.0
 replicaCount: 2

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -111,14 +111,14 @@ Associated with the charts that _Stratio Cloud Provisioner_ installs in all clus
 | v1.18.1
 
 | *cluster-autoscaler*
-| *9.46.6*
+| *9.50.1*
 |
 |
 
 |
 |
 | registry.k8s.io/autoscaling/cluster-autoscaler
-| v1.32.0
+| v1.32.2
 
 | *cluster-operator*
 | *0.5.2*

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -118,7 +118,7 @@ Associated with the charts that _Stratio Cloud Provisioner_ installs in all clus
 |
 |
 | registry.k8s.io/autoscaling/cluster-autoscaler
-| v1.32.2
+| v1.33.0
 
 | *cluster-operator*
 | *0.5.2*

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -111,14 +111,14 @@ Asociadas a los _charts_ que instala _Stratio Cloud Provisioner_ para todos los 
 | v1.18.1
 
 | *cluster-autoscaler*
-| *9.46.6*
+| *9.50.1*
 |
 |
 
 |
 |
 | registry.k8s.io/autoscaling/cluster-autoscaler
-| v1.32.0
+| v1.32.2
 
 | *cluster-operator*
 | *0.5.2*

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -118,7 +118,7 @@ Asociadas a los _charts_ que instala _Stratio Cloud Provisioner_ para todos los 
 |
 |
 | registry.k8s.io/autoscaling/cluster-autoscaler
-| v1.32.2
+| v1.33.0
 
 | *cluster-operator*
 | *0.5.2*


### PR DESCRIPTION
## Description

[PLT-2653] Bump cluster-autoscaler version to v1.33.0

## Related Pull Requests

https://github.com/Stratio/kubernetes-universe/pull/3015

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).



[PLT-2653]: https://stratio.atlassian.net/browse/PLT-2653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ