### PR TITLE
[PLT-2723] Bump aws-ebs-csi-driver, coredns, kube-proxy and vpc-cni addons versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0-0.8.0 (upcoming)
 
+* [PLT-2723] Bump aws-ebs-csi-driver, coredns, kube-proxy and vpc-cni addons versions
 * [PLT-2124] Bump cluster-autoscaler to v1.33.0 version and its chart version to 9.50.1
 * [PLT-2643] Bump aws-load-balancer-controller to v2.13.4
 * [PLT-2656] Bump Tigera Operator version to v3.30.2

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -58,10 +58,10 @@ aws:
       infrastructure-components.yaml: v2.8.4
   managed:
     addons:
-      aws-ebs-csi-driver: v1.39.0-eksbuild.1
-      coredns: v1.11.4-eksbuild.2
-      kube-proxy: v1.32.0-eksbuild.2
-      vpc-cni: v1.19.2-eksbuild.5
+      aws-ebs-csi-driver: v1.47.0-eksbuild.1
+      coredns: v1.11.4-eksbuild.20
+      kube-proxy: v1.32.6-eksbuild.6
+      vpc-cni: v1.20.1-eksbuild.1
     charts:
       aws-load-balancer-controller: 1.13.4
     images:


### PR DESCRIPTION
## Description

Bump addon versions

## Related Pull Requests

https://github.com/Stratio/cluster-operator/pull/296

## Pull Request Checklist:

- [ ] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [ ] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

