### PR TITLE
[PLT-2629] Bump CoreDNS to version v1.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0-0.8.0 (upcoming)
 
+* [PLT-2629] Bump CoreDNS to version 1.12.4
 * [PLT-2660] Bump CSI Azure to version 1.33.4
 * [PLT-2646] Bump cloud-provider-azure, azure-cloud-controller-manager & azure-cloud-node-manager to v1.33.2
 * [PLT-2723] Bump aws-ebs-csi-driver, coredns, kube-proxy and vpc-cni addons versions

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -102,4 +102,4 @@ gcp:
       infrastructure-components.yaml: 1.6.1-0.3.1
   managed:
     images:
-      coredns: v1.9.4
+      coredns: v1.12.4

--- a/docs/images/gcp/imagenes-coredns.txt
+++ b/docs/images/gcp/imagenes-coredns.txt
@@ -1,1 +1,1 @@
-registry.k8s.io/coredns/coredns:v1.9.4
+registry.k8s.io/coredns/coredns:v1.12.4

--- a/pkg/cluster/internal/create/actions/createworker/templates/gcp/32/coredns_deployment.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/gcp/32/coredns_deployment.tmpl
@@ -45,9 +45,9 @@ spec:
       containers:
       - name: coredns
         {{- if .Private }}
-        image: {{ .KeosRegUrl }}/coredns/coredns:v1.9.4
+        image: {{ .KeosRegUrl }}/coredns/coredns:v1.12.4
         {{- else }}
-        image: registry.k8s.io/coredns/coredns:v1.9.4
+        image: registry.k8s.io/coredns/coredns:v1.12.4
         {{- end }}
         imagePullPolicy: IfNotPresent
         resources:

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/gcp-gke-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/gcp-gke-images.adoc
@@ -23,5 +23,5 @@
 |
 |
 | registry.k8s.io/coredns/coredns
-| v1.9.4
+| v1.12.4
 |===

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/gcp-gke-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/gcp-gke-images.adoc
@@ -23,5 +23,5 @@
 |
 |
 | registry.k8s.io/coredns/coredns
-| v1.9.4
+| v1.12.4
 |===


### PR DESCRIPTION
## Description

Bump CoreDNS version from v1.9.4 to v1.12.4

## Related Pull Requests

https://github.com/Stratio/kubernetes-universe/pull/3058

## Pull Request Checklist:

- [x] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [x] [PR desc] Add a summary of the changes made in simple terms.
- [x] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

