### PR TITLE
[PLT-3963] Adapt cloud-provisioner to Semantic Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.17.0-0.9.0 (upcoming)
+## 0.9.0 (upcoming)
 
-* [PLT-3091] Adaptar cloud-provisioner para soportar ECR central: soportar prefijos
+* [PLT-3963] - Adaptar cloud-provisioner a Semantic Versioning
+* [PLT-3091] - Adaptar cloud-provisioner para soportar ECR central: soportar prefijos
 
 ## 0.17.0-0.8.4 (2026-03-25)
 
@@ -12,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.17.0-0.8.3 (2026-03-20)
 
-* [PLT-3877] cloud-provisioner upgrade,  update cluster-operator version
+* [PLT-3877] -  cloud-provisioner upgrade,  update cluster-operator version
 
 ## 0.17.0-0.8.2 (2026-03-19)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,7 @@ hose {
     DEVTIMEOUT = 30
     // Fixed missing closing quote: use golang 1.25.1 image explicitly
     BUILDTOOL_IMAGE = 'golang:1.25.1'
-    VERSIONING_TYPE = 'stratioVersion-3-3'
-    UPSTREAM_VERSION = '0.17.0'
+    VERSIONING_TYPE = "semver"
     DEPLOYONPRS = true
     GRYPE_TEST = true
     MODULE_LIST = [ "paas.cloud-provisioner:cloud-provisioner:tar.gz" ]

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ KIND_BINARY_NAME?=cloud-provisioner
 # - smaller binaries: -w (trim debugger data, but not panics)
 # - metadata: -X=... to bake in git commit
 KIND_VERSION_PKG:=sigs.k8s.io/kind/pkg/cmd/kind/version
-KIND_BUILD_LD_FLAGS:=-X=$(KIND_VERSION_PKG).gitTag=$(TAG) -X=$(KIND_VERSION_PKG).gitCommit=$(COMMIT)
+KIND_BUILD_LD_FLAGS:=-X=$(KIND_VERSION_PKG).gitTag=$(TAG) -X=$(KIND_VERSION_PKG).gitCommit=$(COMMIT) -X=$(KIND_VERSION_PKG).gitCommitCount=$(COMMIT_COUNT)
 KIND_BUILD_FLAGS?=-trimpath -ldflags="-buildid= -w $(KIND_BUILD_LD_FLAGS)"
 ################################################################################
 # ================================= Building ===================================

--- a/bin/change-version.sh
+++ b/bin/change-version.sh
@@ -16,5 +16,5 @@ CORE_VERSION=$(echo "$VERSION" | sed -E "s/-.*//")
 echo "Modifying cloud-provisioner version to: $1"
 echo $VERSION > $BASEDIR/VERSION
 
-sed -i "s/\(const versionCore = \"\)[^\"]*\"/\10.17.0-$CORE_VERSION\"/" "$VERSION_GO_FILE"
+sed -i "s/\(const versionCore = \"\)[^\"]*\"/\1$CORE_VERSION\"/" "$VERSION_GO_FILE"
 sed -i "s/\(const versionPreRelease = \"\)[^\"]*\"/\1SNAPSHOT\"/" "$VERSION_GO_FILE"

--- a/pkg/cluster/internal/providers/docker/images.go
+++ b/pkg/cluster/internal/providers/docker/images.go
@@ -173,10 +173,10 @@ func sanitizeImage(image string) (string, string) {
 
 
 // removePrereleaseHash removes a final dash+hash (e.g., -8214d23) from the image tag,
-// leaving e.g. cloud-provisioner:0.17.0-0.7.0-8214d23 -> cloud-provisioner:0.17.0-0.7.0
+// leaving e.g. cloud-provisioner:0.9.0-8214d23 -> cloud-provisioner:0.9.0
 func removePrereleaseHash(image string) string {
-    // Matches something like :0.17.0-0.7.0-8214d23 at the end and removes the -hash part
-    re := regexp.MustCompile(`^(.+:\d+\.\d+\.\d+-\d+\.\d+\.\d+)-[a-fA-F0-9]{7,}$`)
+    // Matches a git commit hash suffix (7+ hex chars) after a semver tag and removes it
+    re := regexp.MustCompile(`^(.+:\d+\.\d+\.\d+)-[a-fA-F0-9]{7,}$`)
     if matches := re.FindStringSubmatch(image); len(matches) == 2 {
         return matches[1]
     }

--- a/pkg/cluster/internal/providers/docker/images_test.go
+++ b/pkg/cluster/internal/providers/docker/images_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cluster/internal/providers/docker/images_test.go
+++ b/pkg/cluster/internal/providers/docker/images_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"testing"
+)
+
+func Test_removePrereleaseHash(t *testing.T) {
+	cases := []struct {
+		image    string
+		expected string
+	}{
+		// semver: hash suffix is stripped
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0-8214d23",
+			expected: "registry.example.com/cloud-provisioner:0.9.0",
+		},
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0-abc1234def",
+			expected: "registry.example.com/cloud-provisioner:0.9.0",
+		},
+		// semver: pre-release identifiers must NOT be stripped
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0-SNAPSHOT",
+			expected: "registry.example.com/cloud-provisioner:0.9.0-SNAPSHOT",
+		},
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0-alpha.1",
+			expected: "registry.example.com/cloud-provisioner:0.9.0-alpha.1",
+		},
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0-m.3",
+			expected: "registry.example.com/cloud-provisioner:0.9.0-m.3",
+		},
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0-PR42-SNAPSHOT",
+			expected: "registry.example.com/cloud-provisioner:0.9.0-PR42-SNAPSHOT",
+		},
+		// release tag: nothing to strip
+		{
+			image:    "registry.example.com/cloud-provisioner:0.9.0",
+			expected: "registry.example.com/cloud-provisioner:0.9.0",
+		},
+		// no tag at all
+		{
+			image:    "registry.example.com/cloud-provisioner",
+			expected: "registry.example.com/cloud-provisioner",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.image, func(t *testing.T) {
+			t.Parallel()
+			got := removePrereleaseHash(tc.image)
+			if got != tc.expected {
+				t.Errorf("removePrereleaseHash(%q) = %q, want %q", tc.image, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -32,16 +32,20 @@ func Version(useGitCommit bool) string {
 	v := versionCore
 	// add pre-release version info if we have it
 	if versionPreRelease != "" {
-		// If gitTag was set, set it as version
+		// If gitTag was set, use it directly as the full version
 		if gitTag != "" {
 			v = gitTag
 		} else {
-			v += "-" + versionPreRelease
-		}
-		// otherwise if commit was set, add to the pre-release version
-		if useGitCommit && gitCommit != "" {
-			// NOTE: use 14 character short hash, like Kubernetes
-			v += " GitCommit:" + truncate(gitCommit, 14)
+			// Build semver pre-release: SNAPSHOT[.commitCount]
+			preRelease := versionPreRelease
+			if gitCommitCount != "" {
+				preRelease += "." + gitCommitCount
+			}
+			v += "-" + preRelease
+			// Append commit hash as semver build metadata: +hash
+			if useGitCommit && gitCommit != "" {
+				v += "+" + truncate(gitCommit, 14)
+			}
 		}
 	}
 	return v
@@ -55,7 +59,7 @@ func DisplayVersion() string {
 
 // versionCore is the core portion of the kind CLI version per Semantic Versioning 2.0.0
 
-const versionCore = "0.17.0-0.9.0"
+const versionCore = "0.9.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per
 // Semantic Versioning 2.0.0


### PR DESCRIPTION
## Description

- Jenkinsfile: switch VERSIONING_TYPE to semver, remove UPSTREAM_VERSION
- version.go: versionCore is now 0.9.0 (no 0.17.0- prefix); Version() builds proper semver pre-release (SNAPSHOT.count) and build metadata (+hash)
- Makefile: inject gitCommitCount via ldflags so it appears in the binary version
- bin/change-version.sh: remove hardcoded 0.17.0- prefix from sed command
- images.go: update removePrereleaseHash regex for new semver tag format
- images_test.go: add tests for removePrereleaseHash (new file)
- CHANGELOG.md: update upcoming version header to 0.9.0

## Related Pull Requests

N/A

## Pull Request Checklist:

- [X] [PR title] Include a title referencing a ticket in Jira (e.g. "[CLOUDS-99] Implement a new funcionality").
- [X] [PR desc] Add a summary of the changes made in simple terms.
- [ ] [PR desc] List any pull-request related to this change (docs, tests, feature, etc.).
- [ ] [PR labels] Add the corresponding labels (release, skips, cherry-pick, AT-eks-smoke, etc).
- [ ] [Docs] Are changes to the documentation required? (if so, please add references to those PRs).
- [ ] [QA] Are new unit tests required according with the changes? (if so, please add references to those PRs).

