### PR TITLE
[PLT-4161] Backport ecr_pull_through_cache_enabled to 0.17.0-0.8.5

### DIFF
--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -190,7 +190,7 @@ func installLBController(n nodes.Node, k string, privateParams PrivateParams, p 
 	lbControllerManagerHelmParams := lbControllerHelmParams{
 		ClusterName: privateParams.KeosCluster.Metadata.Name,
 		Private:     privateParams.Private,
-		KeosRegUrl:  privateParams.KeosRegUrl,
+		KeosRegUrl:  commons.GetPrefixedRegistryURL("public.ecr.aws", privateParams.KeosRegUrl, privateParams.CentralECR),
 		AccountID:   accountID,
 		RoleName:    roleName,
 	}

--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -244,7 +244,14 @@ spec:
     enableCSIPolicy: true
   nodes:
     extraPolicyAttachments:
-    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`
+    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    extraStatements:
+    - Action:
+        - "ecr:BatchImportUpstreamImage"
+        - "ecr:CreateRepository"
+      Effect: Allow
+      Resource:
+        - "*"`
 
 	// Create the eks.config file in the container
 	eksConfigPath := "/kind/eks.config"

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -46,10 +46,11 @@ type action struct {
 }
 
 type KeosRegistry struct {
-	url          string
-	user         string
-	pass         string
-	registryType string
+	url                  string
+	user                 string
+	pass                 string
+	registryType         string
+	awsCentralECREnabled bool
 }
 
 type HelmRegistry struct {
@@ -147,6 +148,11 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if registry.KeosRegistry {
 			keosRegistry.url = registry.URL
 			keosRegistry.registryType = registry.Type
+			// check if aws_central_ecr is set and enabled (default is false)
+			// and type is ecr
+			if registry.AWSCentralECREnabled && registry.Type == "ecr" {
+				keosRegistry.awsCentralECREnabled = true
+			}
 			continue
 		}
 	}
@@ -171,6 +177,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     a.clusterConfig.Spec.Private,
+			CentralECR:  keosRegistry.awsCentralECREnabled,
 			HelmPrivate: a.clusterConfig.Spec.PrivateHelmRepo,
 		}
 	} else {
@@ -178,6 +185,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     false,
+			CentralECR:  keosRegistry.awsCentralECREnabled,
 		}
 	}
 
@@ -190,7 +198,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if err != nil {
 			return err
 		}
-		c = `sed -i 's|docker.io|` + keosRegistry.url + `|g' /kind/manifests/default-cni.yaml`
+		c = `sed -i 's|docker.io|` + commons.GetPrefixedRegistryURL("docker.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + `|g' /kind/manifests/default-cni.yaml`
 
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
@@ -308,24 +316,25 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 	if privateParams.Private {
 
+		k8sRegUrl := commons.GetPrefixedRegistryURL("registry.k8s.io", keosRegistry.url, keosRegistry.awsCentralECREnabled)
 		c = "echo \"images:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cluster-api:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPI_Version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  bootstrap-kubeadm:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPI_Version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  control-plane-kubeadm:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPI_Version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-aws:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api-aws\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api-aws\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPA_Image_version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-gcp:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/stratio\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPG_Image_version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-azure/cluster-api-azure-controller:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api-azure\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api-azure\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPZ_Image_version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-azure/azureserviceoperator:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/k8s\" >> /root/.cluster-api/clusterctl.yaml && " +
@@ -334,7 +343,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			"echo \"  infrastructure-azure/nmi:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/oss/azure/aad-pod-identity\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cert-manager:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
+			"echo \"    repository: " + commons.GetPrefixedRegistryURL("quay.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
 			return errors.Wrap(err, "failed to add private image registry clusterctl config")
@@ -722,7 +731,9 @@ spec:
 			ctx.Status.Start("Enabling CoreDNS as DNS server 📡")
 			defer ctx.Status.End(false)
 
-			gcpCoreDNSTemplate, err := getManifest(a.keosCluster.Spec.InfraProvider, "coredns_deployment.tmpl", majorVersion, privateParams)
+				coreDNSPrivateParams := privateParams
+			coreDNSPrivateParams.KeosRegUrl = commons.GetPrefixedRegistryURL("registry.k8s.io", privateParams.KeosRegUrl, privateParams.CentralECR)
+			gcpCoreDNSTemplate, err := getManifest(a.keosCluster.Spec.InfraProvider, "coredns_deployment.tmpl", majorVersion, coreDNSPrivateParams)
 
 			coreDNSTemplate := "/kind/coredns-configmap.yaml"
 			coreDNSConfigmap, err := getManifest(a.keosCluster.Spec.InfraProvider, "coredns_configmap.tmpl", majorVersion, a.keosCluster.Spec)

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -50,7 +50,7 @@ type KeosRegistry struct {
 	user                 string
 	pass                 string
 	registryType         string
-	awsCentralECREnabled bool
+	ecrPullThroughCacheEnabled bool
 }
 
 type HelmRegistry struct {
@@ -148,10 +148,10 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if registry.KeosRegistry {
 			keosRegistry.url = registry.URL
 			keosRegistry.registryType = registry.Type
-			// check if aws_central_ecr is set and enabled (default is false)
+			// check if ecr_pull_through_cache is set and enabled (default is false)
 			// and type is ecr
-			if registry.AWSCentralECREnabled && registry.Type == "ecr" {
-				keosRegistry.awsCentralECREnabled = true
+			if registry.ECRPullThroughCacheEnabled && registry.Type == "ecr" {
+				keosRegistry.ecrPullThroughCacheEnabled = true
 			}
 			continue
 		}
@@ -177,7 +177,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     a.clusterConfig.Spec.Private,
-			CentralECR:  keosRegistry.awsCentralECREnabled,
+			CentralECR:  keosRegistry.ecrPullThroughCacheEnabled,
 			HelmPrivate: a.clusterConfig.Spec.PrivateHelmRepo,
 		}
 	} else {
@@ -185,7 +185,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     false,
-			CentralECR:  keosRegistry.awsCentralECREnabled,
+			CentralECR:  keosRegistry.ecrPullThroughCacheEnabled,
 		}
 	}
 
@@ -198,7 +198,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if err != nil {
 			return err
 		}
-		c = `sed -i 's|docker.io|` + commons.GetPrefixedRegistryURL("docker.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + `|g' /kind/manifests/default-cni.yaml`
+		c = `sed -i 's|docker.io|` + commons.GetPrefixedRegistryURL("docker.io", keosRegistry.url, keosRegistry.ecrPullThroughCacheEnabled) + `|g' /kind/manifests/default-cni.yaml`
 
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
@@ -316,7 +316,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 	if privateParams.Private {
 
-		k8sRegUrl := commons.GetPrefixedRegistryURL("registry.k8s.io", keosRegistry.url, keosRegistry.awsCentralECREnabled)
+		k8sRegUrl := commons.GetPrefixedRegistryURL("registry.k8s.io", keosRegistry.url, keosRegistry.ecrPullThroughCacheEnabled)
 		c = "echo \"images:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cluster-api:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
@@ -343,7 +343,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			"echo \"  infrastructure-azure/nmi:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/oss/azure/aad-pod-identity\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cert-manager:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + commons.GetPrefixedRegistryURL("quay.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
+			"echo \"    repository: " + commons.GetPrefixedRegistryURL("quay.io", keosRegistry.url, keosRegistry.ecrPullThroughCacheEnabled) + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
 			return errors.Wrap(err, "failed to add private image registry clusterctl config")

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -179,5 +179,27 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 		return err
 	}
 
+	var awsCentralECREnabled bool
+	// check keosCluster.Spec.DockerRegistries for aws_central_ecr
+	for _, registry := range keosCluster.Spec.DockerRegistries {
+		if registry.Type == "ecr" && registry.AWSCentralECREnabled {
+			awsCentralECREnabled = true
+			break
+		}
+	}
+
+	// Handle override_vars if exists and aws_central_ecr is enabled
+	if awsCentralECREnabled {
+		overrideDir := "override_vars"
+		if info, err := os.Stat(overrideDir); err == nil && info.IsDir() {
+			overrideFile := filepath.Join(overrideDir, "aws_central_ecr_override.yml")
+			content := "aws_central_ecr_enabled: true\n"
+			err = os.WriteFile(overrideFile, []byte(content), 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -179,21 +179,21 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 		return err
 	}
 
-	var awsCentralECREnabled bool
-	// check keosCluster.Spec.DockerRegistries for aws_central_ecr
+	var ecrPullThroughCacheEnabled bool
+	// check keosCluster.Spec.DockerRegistries for ecr_pull_through_cache
 	for _, registry := range keosCluster.Spec.DockerRegistries {
-		if registry.Type == "ecr" && registry.AWSCentralECREnabled {
-			awsCentralECREnabled = true
+		if registry.Type == "ecr" && registry.ECRPullThroughCacheEnabled {
+			ecrPullThroughCacheEnabled = true
 			break
 		}
 	}
 
-	// Handle override_vars if exists and aws_central_ecr is enabled
-	if awsCentralECREnabled {
+	// Handle override_vars if exists and ecr_pull_through_cache is enabled
+	if ecrPullThroughCacheEnabled {
 		overrideDir := "override_vars"
 		if info, err := os.Stat(overrideDir); err == nil && info.IsDir() {
-			overrideFile := filepath.Join(overrideDir, "aws_central_ecr_override.yml")
-			content := "aws_central_ecr_enabled: true\n"
+			overrideFile := filepath.Join(overrideDir, "ecr_pull_through_cache_override.yml")
+			content := "ecr_pull_through_cache_enabled: true\n"
 			err = os.WriteFile(overrideFile, []byte(content), 0644)
 			if err != nil {
 				return err

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -27,9 +27,10 @@ import (
 
 type KEOSDescriptor struct {
 	DockerRegistry struct {
-		AuthRequired bool   `yaml:"auth_required"`
-		Type         string `yaml:"type"`
-		URL          string `yaml:"url"`
+		AuthRequired              bool   `yaml:"auth_required"`
+		Type                      string `yaml:"type"`
+		URL                       string `yaml:"url"`
+		ECRPullThroughCacheEnabled bool  `yaml:"ecr_pull_through_cache_enabled,omitempty"`
 	} `yaml:"docker_registry"`
 	HelmRepository struct {
 		AuthRequired bool   `yaml:"auth_required"`
@@ -97,6 +98,7 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 			keosDescriptor.DockerRegistry.URL = registry.URL
 			keosDescriptor.DockerRegistry.AuthRequired = registry.AuthRequired
 			keosDescriptor.DockerRegistry.Type = registry.Type
+			keosDescriptor.DockerRegistry.ECRPullThroughCacheEnabled = registry.ECRPullThroughCacheEnabled
 		}
 	}
 
@@ -177,28 +179,6 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 	err = os.WriteFile("keos.yaml", []byte(keosYAMLData), 0644)
 	if err != nil {
 		return err
-	}
-
-	var ecrPullThroughCacheEnabled bool
-	// check keosCluster.Spec.DockerRegistries for ecr_pull_through_cache
-	for _, registry := range keosCluster.Spec.DockerRegistries {
-		if registry.Type == "ecr" && registry.ECRPullThroughCacheEnabled {
-			ecrPullThroughCacheEnabled = true
-			break
-		}
-	}
-
-	// Handle override_vars if exists and ecr_pull_through_cache is enabled
-	if ecrPullThroughCacheEnabled {
-		overrideDir := "override_vars"
-		if info, err := os.Stat(overrideDir); err == nil && info.IsDir() {
-			overrideFile := filepath.Join(overrideDir, "ecr_pull_through_cache_override.yml")
-			content := "ecr_pull_through_cache_enabled: true\n"
-			err = os.WriteFile(overrideFile, []byte(content), 0644)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -84,6 +84,7 @@ type ChartsDictionary struct {
 type PrivateParams struct {
 	KeosCluster commons.KeosCluster
 	KeosRegUrl  string
+	CentralECR  bool
 	Private     bool
 	HelmPrivate bool
 }
@@ -160,6 +161,7 @@ type helmRepository struct {
 type calicoHelmParams struct {
 	Spec           commons.KeosSpec
 	KeosRegUrl     string
+	QuayRegUrl     string
 	Private        bool
 	IsNetPolEngine bool
 	Annotations    map[string]string
@@ -168,6 +170,7 @@ type calicoHelmParams struct {
 type commonHelmParams struct {
 	KeosRegUrl string
 	Private    bool
+	CentralECR bool
 }
 
 type cloudControllerHelmParams struct {
@@ -420,6 +423,12 @@ func (p *Provider) deployCertManager(n nodes.Node, keosRegistryUrl string, kubec
 	certManagerHelmParams := commonHelmParams{
 		KeosRegUrl: keosRegistryUrl,
 		Private:    privateParams.Private,
+		CentralECR: privateParams.CentralECR,
+	}
+
+	// if central ecr is enabled add suffix to the image
+	if privateParams.CentralECR {
+		certManagerHelmParams.KeosRegUrl = commons.GetPrefixedRegistryURL("quay.io", privateParams.KeosRegUrl, privateParams.CentralECR)
 	}
 	certManagerHelmValues, err := getManifest("common", "cert-manager-helm-values.tmpl", majorVersion, certManagerHelmParams)
 	if err != nil {
@@ -671,7 +680,8 @@ func installCalico(n nodes.Node, k string, privateParams PrivateParams, isNetPol
 
 	calicoHelmParams := calicoHelmParams{
 		Spec:           keosCluster.Spec,
-		KeosRegUrl:     privateParams.KeosRegUrl,
+		KeosRegUrl:     commons.GetPrefixedRegistryURL("docker.io", privateParams.KeosRegUrl, privateParams.CentralECR),
+		QuayRegUrl:     commons.GetPrefixedRegistryURL("quay.io", privateParams.KeosRegUrl, privateParams.CentralECR),
 		Private:        privateParams.Private,
 		IsNetPolEngine: isNetPolEngine,
 		Annotations: map[string]string{
@@ -679,6 +689,10 @@ func installCalico(n nodes.Node, k string, privateParams PrivateParams, isNetPol
 		},
 	}
 
+	// if CentralECR is enabled add suffix to the image
+	if privateParams.CentralECR {
+		privateParams.KeosRegUrl = commons.GetPrefixedRegistryURL("quay.io", privateParams.KeosRegUrl, privateParams.CentralECR)
+	}
 	// Generate the calico helm values
 	calicoHelmValues, err := getManifest("common", "tigera-operator-helm-values.tmpl", majorVersion, calicoHelmParams)
 
@@ -733,6 +747,10 @@ func deployClusterAutoscaler(n nodes.Node, chartsList map[string]commons.ChartEn
 		clusterAutoscalerHelmReleaseParams.ChartRepoRef = "cluster-autoscaler"
 	}
 
+	// if Central ECR is enabled add suffix to the image
+	if privateParams.CentralECR {
+		privateParams.KeosRegUrl = commons.GetPrefixedRegistryURL("registry.k8s.io", privateParams.KeosRegUrl, privateParams.CentralECR)
+	}
 	helmValuesCA, err := getManifest("common", "cluster-autoscaler-helm-values.tmpl", majorVersion, privateParams)
 	if err != nil {
 		return errors.Wrap(err, "failed to get CA helm values")
@@ -787,6 +805,11 @@ func configureFlux(n nodes.Node, k string, privateParams PrivateParams, helmRepo
 	fluxHelmParams := commonHelmParams{
 		KeosRegUrl: privateParams.KeosRegUrl,
 		Private:    privateParams.Private,
+	}
+
+	// if Central ECR is enabled add suffix to the image
+	if privateParams.CentralECR {
+		fluxHelmParams.KeosRegUrl = commons.GetPrefixedRegistryURL("ghcr.io", privateParams.KeosRegUrl, privateParams.CentralECR)
 	}
 
 	// Generate the flux helm values

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
@@ -78,7 +78,7 @@ resources: {}
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
 {{- if $.Private }}
-  registry: {{ $.KeosRegUrl }}
+  registry: {{ $.QuayRegUrl }}
 {{- else }}
   registry: quay.io
 {{- end }}

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -32,8 +32,16 @@ import (
 var (
 	capi_version = "v1.10.8"
 	capa_version = "v2.9.2"
-	capz_version = "v1.21.1"
 	capg_version = "1.6.1-0.4.0"
+	capz_version = "v1.21.1"
+)
+
+const (
+	DefaultDockerhubPrefix = "/dockerhub"
+	DefaultEcrpublicPrefix = "/ecrpublic"
+	DefaultGhcrPrefix      = "/ghcr"
+	DefaultK8sPrefix       = "/k8s"
+	DefaultQuayPrefix      = "/quay"
 )
 
 type Resource struct {
@@ -400,10 +408,11 @@ type DockerRegistryCredentials struct {
 }
 
 type DockerRegistry struct {
-	AuthRequired bool   `yaml:"auth_required" validate:"boolean"`
-	Type         string `yaml:"type" validate:"required,oneof='acr' 'ecr' 'gar' 'gcr' 'generic'"`
-	URL          string `yaml:"url" validate:"required"`
-	KeosRegistry bool   `yaml:"keos_registry" validate:"boolean"`
+	AuthRequired         bool   `yaml:"auth_required" validate:"boolean"`
+	Type                 string `yaml:"type" validate:"required,oneof='acr' 'ecr' 'gar' 'gcr' 'generic'"`
+	URL                  string `yaml:"url" validate:"required"`
+	KeosRegistry         bool   `yaml:"keos_registry" validate:"boolean"`
+	AWSCentralECREnabled bool   `yaml:"aws_central_ecr_enabled" validate:"boolean"`
 }
 
 type HelmRepositoryCredentials struct {
@@ -596,6 +605,29 @@ func (s KeosSpec) Init() KeosSpec {
 	s.Dns.ManageZone = true
 
 	return s
+}
+
+// GetPrefixedRegistryURL returns the registry URL with prefix if appropriate
+func GetPrefixedRegistryURL(originalRegistry string, baseRegistryURL string, awsCentralECREnabled bool) string {
+	if !awsCentralECREnabled || baseRegistryURL == "" {
+		return baseRegistryURL
+	}
+
+	prefix := ""
+	switch {
+	case strings.Contains(originalRegistry, "docker.io"):
+		prefix = DefaultDockerhubPrefix
+	case strings.Contains(originalRegistry, "public.ecr.aws"):
+		prefix = DefaultEcrpublicPrefix
+	case strings.Contains(originalRegistry, "ghcr.io"):
+		prefix = DefaultGhcrPrefix
+	case strings.Contains(originalRegistry, "quay.io"):
+		prefix = DefaultQuayPrefix
+	case strings.Contains(originalRegistry, "k8s.io"):
+		prefix = DefaultK8sPrefix
+	}
+
+	return baseRegistryURL + prefix
 }
 
 // Validator for WorkloadPool field

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -412,7 +412,7 @@ type DockerRegistry struct {
 	Type                 string `yaml:"type" validate:"required,oneof='acr' 'ecr' 'gar' 'gcr' 'generic'"`
 	URL                  string `yaml:"url" validate:"required"`
 	KeosRegistry         bool   `yaml:"keos_registry" validate:"boolean"`
-	AWSCentralECREnabled bool   `yaml:"aws_central_ecr_enabled" validate:"boolean"`
+	ECRPullThroughCacheEnabled bool   `yaml:"ecr_pull_through_cache_enabled" validate:"boolean"`
 }
 
 type HelmRepositoryCredentials struct {
@@ -608,8 +608,8 @@ func (s KeosSpec) Init() KeosSpec {
 }
 
 // GetPrefixedRegistryURL returns the registry URL with prefix if appropriate
-func GetPrefixedRegistryURL(originalRegistry string, baseRegistryURL string, awsCentralECREnabled bool) string {
-	if !awsCentralECREnabled || baseRegistryURL == "" {
+func GetPrefixedRegistryURL(originalRegistry string, baseRegistryURL string, ecrPullThroughCacheEnabled bool) string {
+	if !ecrPullThroughCacheEnabled || baseRegistryURL == "" {
 		return baseRegistryURL
 	}
 

--- a/pkg/commons/cluster_test.go
+++ b/pkg/commons/cluster_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commons
+
+import (
+	"testing"
+)
+
+func TestGetPrefixedRegistryURL(t *testing.T) {
+	baseURL := "123456789.dkr.ecr.eu-west-1.amazonaws.com"
+
+	tests := []struct {
+		name                 string
+		originalRegistry     string
+		baseRegistryURL      string
+		awsCentralECREnabled bool
+		expected             string
+	}{
+		// CentralECR enabled — all 5 known registry mappings
+		{
+			name:                 "docker.io maps to /dockerhub suffix",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultDockerhubPrefix,
+		},
+		{
+			name:                 "public.ecr.aws maps to /ecrpublic suffix",
+			originalRegistry:     "public.ecr.aws",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultEcrpublicPrefix,
+		},
+		{
+			name:                 "ghcr.io maps to /ghcr suffix",
+			originalRegistry:     "ghcr.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultGhcrPrefix,
+		},
+		{
+			name:                 "quay.io maps to /quay suffix",
+			originalRegistry:     "quay.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultQuayPrefix,
+		},
+		{
+			name:                 "k8s.io maps to /k8s suffix",
+			originalRegistry:     "k8s.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultK8sPrefix,
+		},
+		// registry.k8s.io also matches the k8s.io case via strings.Contains
+		{
+			name:                 "registry.k8s.io maps to /k8s suffix via strings.Contains",
+			originalRegistry:     "registry.k8s.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultK8sPrefix,
+		},
+		// Unknown registry returns base URL unchanged
+		{
+			name:                 "unknown registry returns base URL unchanged",
+			originalRegistry:     "mcr.microsoft.com",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL,
+		},
+		// CentralECR disabled — always returns base URL unchanged
+		{
+			name:                 "CentralECR disabled returns base URL for docker.io",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: false,
+			expected:             baseURL,
+		},
+		{
+			name:                 "CentralECR disabled returns base URL for quay.io",
+			originalRegistry:     "quay.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: false,
+			expected:             baseURL,
+		},
+		{
+			name:                 "CentralECR disabled returns base URL for registry.k8s.io",
+			originalRegistry:     "registry.k8s.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: false,
+			expected:             baseURL,
+		},
+		// Empty base URL returns empty string
+		{
+			name:                 "empty base URL returns empty string when CentralECR enabled",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      "",
+			awsCentralECREnabled: true,
+			expected:             "",
+		},
+		{
+			name:                 "empty base URL returns empty string when CentralECR disabled",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      "",
+			awsCentralECREnabled: false,
+			expected:             "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPrefixedRegistryURL(tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled)
+			if got != tt.expected {
+				t.Errorf("GetPrefixedRegistryURL(%q, %q, %v) = %q, want %q",
+					tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/commons/cluster_test.go
+++ b/pkg/commons/cluster_test.go
@@ -27,7 +27,7 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 		name                 string
 		originalRegistry     string
 		baseRegistryURL      string
-		awsCentralECREnabled bool
+		ecrPullThroughCacheEnabled bool
 		expected             string
 	}{
 		// CentralECR enabled — all 5 known registry mappings
@@ -35,35 +35,35 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "docker.io maps to /dockerhub suffix",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultDockerhubPrefix,
 		},
 		{
 			name:                 "public.ecr.aws maps to /ecrpublic suffix",
 			originalRegistry:     "public.ecr.aws",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultEcrpublicPrefix,
 		},
 		{
 			name:                 "ghcr.io maps to /ghcr suffix",
 			originalRegistry:     "ghcr.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultGhcrPrefix,
 		},
 		{
 			name:                 "quay.io maps to /quay suffix",
 			originalRegistry:     "quay.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultQuayPrefix,
 		},
 		{
 			name:                 "k8s.io maps to /k8s suffix",
 			originalRegistry:     "k8s.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultK8sPrefix,
 		},
 		// registry.k8s.io also matches the k8s.io case via strings.Contains
@@ -71,7 +71,7 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "registry.k8s.io maps to /k8s suffix via strings.Contains",
 			originalRegistry:     "registry.k8s.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultK8sPrefix,
 		},
 		// Unknown registry returns base URL unchanged
@@ -79,7 +79,7 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "unknown registry returns base URL unchanged",
 			originalRegistry:     "mcr.microsoft.com",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL,
 		},
 		// CentralECR disabled — always returns base URL unchanged
@@ -87,21 +87,21 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "CentralECR disabled returns base URL for docker.io",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             baseURL,
 		},
 		{
 			name:                 "CentralECR disabled returns base URL for quay.io",
 			originalRegistry:     "quay.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             baseURL,
 		},
 		{
 			name:                 "CentralECR disabled returns base URL for registry.k8s.io",
 			originalRegistry:     "registry.k8s.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             baseURL,
 		},
 		// Empty base URL returns empty string
@@ -109,24 +109,24 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "empty base URL returns empty string when CentralECR enabled",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      "",
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             "",
 		},
 		{
 			name:                 "empty base URL returns empty string when CentralECR disabled",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      "",
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetPrefixedRegistryURL(tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled)
+			got := GetPrefixedRegistryURL(tt.originalRegistry, tt.baseRegistryURL, tt.ecrPullThroughCacheEnabled)
 			if got != tt.expected {
 				t.Errorf("GetPrefixedRegistryURL(%q, %q, %v) = %q, want %q",
-					tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled, got, tt.expected)
+					tt.originalRegistry, tt.baseRegistryURL, tt.ecrPullThroughCacheEnabled, got, tt.expected)
 			}
 		})
 	}

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -157,6 +157,7 @@ def parse_args():
     parser.add_argument("--disable-prepare-capsule", action="store_true", help="Disable preparing capsule for the upgrade process (enabled by default)")
     parser.add_argument("--dry-run", action="store_true", help="Do not upgrade components. This invalidates all other options")
     parser.add_argument("--private", action="store_true", help="Treats the Docker registry and the Helm repository as private")
+    parser.add_argument("--ecr-pull-through", action="store_true", help="Force ECR pull-through cache mode regardless of KeosCluster spec")
     args = parser.parse_args()
     return vars(args)
 
@@ -623,8 +624,10 @@ def get_keos_registry_url(keos_cluster):
     return ""
 
 def is_ecr_pull_through_enabled(keos_cluster):
-    '''Return True if ECR pull-through cache is enabled in the cluster'''
+    '''Return True if ECR pull-through cache is enabled in the cluster or forced via --ecr-pull-through flag'''
 
+    if config.get("ecr_pull_through", False):
+        return True
     for registry in keos_cluster["spec"].get("docker_registries", []):
         if registry.get("ecr_pull_through_cache_enabled", False):
             return True

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -717,6 +717,24 @@ def update_tigera_operator_image_tag_value(values_file):
         values['calicoctl']['tag'] = TIGERA_OPERATOR_CALICOCTL_VERSION
         values['tigeraOperator']['version'] = TIGERA_OPERATOR_CONTROLLER_VERSION
 
+        # Apply ECR pull-through prefixes to registry fields.
+        # The registry URL is stored separately from the image path in tigera values,
+        # so string substitution in create_default_values() never matches — must be done here.
+        if is_ecr_pull_through_enabled(keos_cluster):
+            registry_url = get_keos_registry_url(keos_cluster)
+            quay_registry = f"{registry_url}/quay"
+            dockerhub_registry = f"{registry_url}/dockerhub"
+            if values.get('tigeraOperator', {}).get('registry', '').startswith(registry_url) and \
+               not values['tigeraOperator']['registry'].startswith(quay_registry):
+                values['tigeraOperator']['registry'] = quay_registry
+            if values.get('installation', {}).get('registry', '').startswith(registry_url) and \
+               not values['installation']['registry'].startswith(quay_registry):
+                values['installation']['registry'] = quay_registry
+            calico_image = values.get('calicoctl', {}).get('image', '')
+            if calico_image.startswith(registry_url) and not calico_image.startswith(dockerhub_registry):
+                values['calicoctl']['image'] = calico_image.replace(
+                    f"{registry_url}/calico", f"{dockerhub_registry}/calico", 1)
+
         with open(values_file, 'w') as file:
             yaml.safe_dump(values, file, default_flow_style=False)
 

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -622,6 +622,14 @@ def get_keos_registry_url(keos_cluster):
             return registry["url"]
     return ""
 
+def is_ecr_pull_through_enabled(keos_cluster):
+    '''Return True if ECR pull-through cache is enabled in the cluster'''
+
+    for registry in keos_cluster["spec"].get("docker_registries", []):
+        if registry.get("ecr_pull_through_cache_enabled", False):
+            return True
+    return False
+
 def get_pods_cidr(keos_cluster):
     '''Get the pods CIDR'''
 
@@ -669,6 +677,17 @@ def create_default_values(chart_name, namespace, values_file, provider):
             values = render_values_template( f"values/{provider}/{chart_name}_default_values.tmpl", keos_cluster, cluster_config)
         else:
             values, err = run_command(f"{helm} get values {chart_name} -n {namespace} --output yaml")
+        if is_ecr_pull_through_enabled(keos_cluster):
+            registry_url = get_keos_registry_url(keos_cluster)
+            pull_through_substitutions = [
+                (f"{registry_url}/tigera",    f"{registry_url}/quay/tigera"),
+                (f"{registry_url}/jetstack",  f"{registry_url}/quay/jetstack"),
+                (f"{registry_url}/fluxcd",    f"{registry_url}/ghcr/fluxcd"),
+                (f"{registry_url}/autoscaling", f"{registry_url}/k8s/autoscaling"),
+                (f"{registry_url}/eks/",      f"{registry_url}/ecrpublic/eks/"),
+            ]
+            for old, new in pull_through_substitutions:
+                values = values.replace(old, new)
         run_command(f"echo '{values}' > {values_file}")
     except Exception as e:
         raise
@@ -973,7 +992,7 @@ def update_clusterconfig(cluster_config, charts, provider, cluster_operator_vers
         print(f"[ERROR] Error updating the clusterconfig: {e}")
         raise e
 
-def create_clusterctl_config_for_private_registry(registry_url, provider):
+def create_clusterctl_config_for_private_registry(registry_url, provider, pull_through=False):
     """Create or update clusterctl config file to use private registry"""
     print("[INFO] Configuring clusterctl for private registry:", end=" ", flush=True)
 
@@ -1000,26 +1019,29 @@ def create_clusterctl_config_for_private_registry(registry_url, provider):
     if 'images' not in config_data:
         config_data['images'] = {}
 
+    k8s_prefix  = "k8s/"  if pull_through else ""
+    quay_prefix = "quay/" if pull_through else ""
+
     # Align the image overrides with the original installation logic.
     config_data['images']['cluster-api'] = {
-        'repository': f"{registry_url}/cluster-api",
+        'repository': f"{registry_url}/{k8s_prefix}cluster-api",
         'tag': CAPI,
     }
     config_data['images']['bootstrap-kubeadm'] = {
-        'repository': f"{registry_url}/cluster-api",
+        'repository': f"{registry_url}/{k8s_prefix}cluster-api",
         'tag': CAPI,
     }
     config_data['images']['control-plane-kubeadm'] = {
-        'repository': f"{registry_url}/cluster-api",
+        'repository': f"{registry_url}/{k8s_prefix}cluster-api",
         'tag': CAPI,
     }
     config_data['images']['cert-manager'] = {
-        'repository': f"{registry_url}/jetstack"
+        'repository': f"{registry_url}/{quay_prefix}jetstack"
     }
 
     if provider == "aws":
         config_data['images']['infrastructure-aws'] = {
-            'repository': f"{registry_url}/cluster-api-aws",
+            'repository': f"{registry_url}/{k8s_prefix}cluster-api-aws",
             'tag': CAPA,
         }
     elif provider == "gcp":
@@ -1842,7 +1864,7 @@ if __name__ == '__main__':
     if private_registry:
         registry_url = get_keos_registry_url(keos_cluster)
         print(f"[DEBUG] Using private registry: {registry_url}")
-        create_clusterctl_config_for_private_registry(registry_url, provider)
+        create_clusterctl_config_for_private_registry(registry_url, provider, pull_through=is_ecr_pull_through_enabled(keos_cluster))
         if provider == "gcp":
             # Also patch GCP CRDs to remove conversion webhooks (caBundle issue)
             config_dir = os.path.expanduser("~/.cluster-api")

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -780,6 +780,42 @@ def filter_installed_charts(charts):
         print(f"[ERROR] Error getting charts installed {e}.")
         raise e
 
+def apply_chart_crds(chart_name, chart_version, repo_url, repo_schema):
+    '''Pull chart and apply CRDs — Helm upgrade never updates CRDs, must be done explicitly'''
+
+    import tempfile
+    import glob
+
+    print(f"[INFO] Applying CRDs for {chart_name} {chart_version}:", end=" ", flush=True)
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if repo_schema == "oci":
+                pull_cmd = f"{helm} pull {repo_url}/{chart_name} --version {chart_version} -d {tmpdir}"
+            else:
+                pull_cmd = f"{helm} pull {chart_name} --repo {repo_url} --version {chart_version} -d {tmpdir}"
+            run_command(pull_cmd)
+
+            tarballs = glob.glob(f"{tmpdir}/*.tgz")
+            if not tarballs:
+                print("SKIP (no tarball found)")
+                return
+
+            tarball = tarballs[0]
+            run_command(f"tar xzf {tarball} -C {tmpdir} {chart_name}/crds/ 2>/dev/null || true")
+
+            crd_files = glob.glob(f"{tmpdir}/{chart_name}/crds/*.yaml")
+            if not crd_files:
+                print("SKIP (no CRDs in chart)")
+                return
+
+            for crd_file in crd_files:
+                run_command(f"{kubectl} apply -f {crd_file}")
+
+        print("OK")
+    except Exception as e:
+        print(f"WARN ({e}) — continuing without CRD update")
+
+
 def upgrade_chart(chart_name, chart_data):
     '''Update chart HelmRelease'''
     chart_repo = chart_data["repo"]
@@ -857,6 +893,9 @@ def upgrade_chart(chart_name, chart_data):
             'HelmReleaseInterval': '1m',
             'HelmReleaseRetries': 3
         }
+
+        if chart_name == "cluster-operator":
+            apply_chart_crds(chart_name, chart_version, repo_url, repo_schema)
 
         helmrepository_yaml = helmrepository_template.render(helm_repo_data)
         helmrelease_yaml = helmrelease_template.render(helm_release_data)

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -1842,7 +1842,7 @@ if __name__ == '__main__':
         charts_to_upgrade.update(aws_eks_charts_installed)
     elif provider == "azure":
         charts_to_upgrade.update(azure_vm_charts)
-    charts_to_upgrade["cluster-operator"]["chart_version"] = cluster_operator_version
+    charts_to_upgrade["cluster-operator"]["version"] = cluster_operator_version
 
     # Filter out charts that are not installed to avoid errors
     charts_to_upgrade = filter_installed_charts(charts_to_upgrade)

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -790,6 +790,10 @@ def apply_chart_crds(chart_name, chart_version, repo_url, repo_schema):
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
             if repo_schema == "oci":
+                registry = repo_url.replace("oci://", "").split("/")[0]
+                if ".dkr.ecr." in registry:
+                    region = registry.split(".")[3]
+                    run_command(f"aws ecr get-login-password --region {region} | {helm} registry login {registry} --username AWS --password-stdin")
                 pull_cmd = f"{helm} pull {repo_url}/{chart_name} --version {chart_version} -d {tmpdir}"
             else:
                 pull_cmd = f"{helm} pull {chart_name} --repo {repo_url} --version {chart_version} -d {tmpdir}"


### PR DESCRIPTION
## Summary
- Backport of `aws_central_ecr_enabled` feature (ECR central pull-through cache) from master to `branch-0.17.0-0.8`
- Cherry-pick of commit `787849f3` filtering out Claude/tooling files
- No conflicts — key files unchanged in release branch

## Files
- `pkg/commons/cluster.go` — `AWSCentralECREnabled` field + `GetPrefixedRegistryURL()` + prefix constants
- `pkg/commons/cluster_test.go` — unit tests for `GetPrefixedRegistryURL`
- `pkg/cluster/.../createworker/createworker.go` — reads flag, rewrites CNI/clusterctl URLs
- `pkg/cluster/.../createworker/keosinstaller.go` — generates `aws_central_ecr_override.yml`
- `pkg/cluster/.../createworker/provider.go` — rewrites Helm values URLs
- `pkg/cluster/.../createworker/aws.go` — LB Controller ECR public prefix
- `tigera-operator-helm-values.tmpl` — uses `QuayRegUrl` for tigera registry

## Test plan
- [ ] Build OK: `cloud-provisioner Version:0.17.0-0.8.5-SNAPSHOT GitCommit:64a54885`
- [ ] Create cluster with `aws_central_ecr_enabled: true` and verify prefixed URLs in generated files