### PR TITLE
[PLT-4162] Backport ecr_pull_through_cache_enabled to 0.17.0-0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0-0.7.5 (upcoming)
 
+* [PLT-4162] Bump cluster-operator to 0.5.3 version
 * Remove DoAT on jenkinsfile
 
 ## 0.17.0-0.7.4 (2025-12-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 0.17.0-0.7.5 (upcoming)
 
-* [PLT-3091] Add ECR pull-through cache migration script for calico, flux and tigera components
-* [PLT-4162] Bump cluster-operator to 0.5.3 version
+* [PLT-4162] Add ECR pull-through cache migration script; bump cluster-operator to 0.5.3
 * Remove DoAT on jenkinsfile
 
 ## 0.17.0-0.7.4 (2025-12-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0-0.7.5 (upcoming)
 
+* [PLT-3091] Add ECR pull-through cache migration script for calico, flux and tigera components
 * [PLT-4162] Bump cluster-operator to 0.5.3 version
 * Remove DoAT on jenkinsfile
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -25,7 +25,7 @@ core:
       cert-manager-webhook: v1.17.0
     cluster-autoscaler: v1.32.0
     cluster-operator:
-      cluster-operator: 0.5.2
+      cluster-operator: 0.5.3
       kube-rbac-proxy: v0.15.0
     flux:
       flux-cli: v2.4.0
@@ -43,7 +43,7 @@ core:
   charts:
     cert-manager: v1.17.0
     cluster-autoscaler: 9.46.6
-    cluster-operator: 0.5.2
+    cluster-operator: 0.5.3
     flux: 2.14.1
     tigera-operator: v3.29.1
 aws:

--- a/bin/images/commons/imagenes-cluster-operator.txt
+++ b/bin/images/commons/imagenes-cluster-operator.txt
@@ -1,2 +1,2 @@
 gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
-stratio-releases.repo.stratio.com/stratio/cluster-operator:0.5.2
+stratio-releases.repo.stratio.com/stratio/cluster-operator:0.5.3

--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -337,7 +337,14 @@ spec:
     enableCSIPolicy: true
   nodes:
     extraPolicyAttachments:
-    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`
+    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    extraStatements:
+    - Action:
+        - "ecr:BatchImportUpstreamImage"
+        - "ecr:CreateRepository"
+      Effect: Allow
+      Resource:
+        - "*"`
 
 	// Create the eks.config file in the container
 	eksConfigPath := "/kind/eks.config"

--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -283,7 +283,7 @@ func installLBController(n nodes.Node, k string, privateParams PrivateParams, p 
 	lbControllerManagerHelmParams := lbControllerHelmParams{
 		ClusterName: privateParams.KeosCluster.Metadata.Name,
 		Private:     privateParams.Private,
-		KeosRegUrl:  privateParams.KeosRegUrl,
+		KeosRegUrl:  commons.GetPrefixedRegistryURL("public.ecr.aws", privateParams.KeosRegUrl, privateParams.CentralECR),
 		AccountID:   accountID,
 		RoleName:    roleName,
 	}

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -43,10 +43,11 @@ type action struct {
 }
 
 type KeosRegistry struct {
-	url          string
-	user         string
-	pass         string
-	registryType string
+	url                  string
+	user                 string
+	pass                 string
+	registryType         string
+	awsCentralECREnabled bool
 }
 
 type HelmRegistry struct {
@@ -144,6 +145,11 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if registry.KeosRegistry {
 			keosRegistry.url = registry.URL
 			keosRegistry.registryType = registry.Type
+			// check if aws_central_ecr is set and enabled (default is false)
+			// and type is ecr
+			if registry.AWSCentralECREnabled && registry.Type == "ecr" {
+				keosRegistry.awsCentralECREnabled = true
+			}
 			continue
 		}
 	}
@@ -169,6 +175,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     a.clusterConfig.Spec.Private,
+			CentralECR:  keosRegistry.awsCentralECREnabled,
 			HelmPrivate: a.clusterConfig.Spec.PrivateHelmRepo,
 		}
 	} else {
@@ -176,6 +183,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     false,
+			CentralECR:  keosRegistry.awsCentralECREnabled,
 		}
 	}
 
@@ -188,7 +196,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if err != nil {
 			return err
 		}
-		c = `sed -i 's|docker.io|` + keosRegistry.url + `|g' /kind/manifests/default-cni.yaml`
+		c = `sed -i 's|docker.io|` + commons.GetPrefixedRegistryURL("docker.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + `|g' /kind/manifests/default-cni.yaml`
 
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
@@ -306,24 +314,25 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 	if privateParams.Private {
 
+		k8sRegUrl := commons.GetPrefixedRegistryURL("registry.k8s.io", keosRegistry.url, keosRegistry.awsCentralECREnabled)
 		c = "echo \"images:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cluster-api:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPI_Version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  bootstrap-kubeadm:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPI_Version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  control-plane-kubeadm:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPI_Version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-aws:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api-aws\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api-aws\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPA_Image_version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-gcp:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/stratio\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPG_Image_version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-azure/cluster-api-azure-controller:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/cluster-api-azure\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + k8sRegUrl + "/cluster-api-azure\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    tag: " + a.clusterConfig.Spec.Capx.CAPZ_Image_version + "\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-azure/azureserviceoperator:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/k8s\" >> /root/.cluster-api/clusterctl.yaml && " +
@@ -332,7 +341,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			"echo \"  infrastructure-azure/nmi:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/oss/azure/aad-pod-identity\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cert-manager:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
+			"echo \"    repository: " + commons.GetPrefixedRegistryURL("quay.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
 			return errors.Wrap(err, "failed to add private image registry clusterctl config")
@@ -704,7 +713,9 @@ spec:
 			ctx.Status.Start("Enabling CoreDNS as DNS server 📡")
 			defer ctx.Status.End(false)
 
-			gcpCoreDNSTemplate, err := getManifest(a.keosCluster.Spec.InfraProvider, "coredns_deployment.tmpl", majorVersion, privateParams)
+				coreDNSPrivateParams := privateParams
+			coreDNSPrivateParams.KeosRegUrl = commons.GetPrefixedRegistryURL("registry.k8s.io", privateParams.KeosRegUrl, privateParams.CentralECR)
+			gcpCoreDNSTemplate, err := getManifest(a.keosCluster.Spec.InfraProvider, "coredns_deployment.tmpl", majorVersion, coreDNSPrivateParams)
 
 			coreDNSTemplate := "/kind/coredns-configmap.yaml"
 			coreDNSConfigmap, err := getManifest(a.keosCluster.Spec.InfraProvider, "coredns_configmap.tmpl", majorVersion, a.keosCluster.Spec)

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -47,7 +47,7 @@ type KeosRegistry struct {
 	user                 string
 	pass                 string
 	registryType         string
-	awsCentralECREnabled bool
+	ecrPullThroughCacheEnabled bool
 }
 
 type HelmRegistry struct {
@@ -145,10 +145,10 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if registry.KeosRegistry {
 			keosRegistry.url = registry.URL
 			keosRegistry.registryType = registry.Type
-			// check if aws_central_ecr is set and enabled (default is false)
+			// check if ecr_pull_through_cache is set and enabled (default is false)
 			// and type is ecr
-			if registry.AWSCentralECREnabled && registry.Type == "ecr" {
-				keosRegistry.awsCentralECREnabled = true
+			if registry.ECRPullThroughCacheEnabled && registry.Type == "ecr" {
+				keosRegistry.ecrPullThroughCacheEnabled = true
 			}
 			continue
 		}
@@ -175,7 +175,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     a.clusterConfig.Spec.Private,
-			CentralECR:  keosRegistry.awsCentralECREnabled,
+			CentralECR:  keosRegistry.ecrPullThroughCacheEnabled,
 			HelmPrivate: a.clusterConfig.Spec.PrivateHelmRepo,
 		}
 	} else {
@@ -183,7 +183,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			KeosCluster: a.keosCluster,
 			KeosRegUrl:  keosRegistry.url,
 			Private:     false,
-			CentralECR:  keosRegistry.awsCentralECREnabled,
+			CentralECR:  keosRegistry.ecrPullThroughCacheEnabled,
 		}
 	}
 
@@ -196,7 +196,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		if err != nil {
 			return err
 		}
-		c = `sed -i 's|docker.io|` + commons.GetPrefixedRegistryURL("docker.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + `|g' /kind/manifests/default-cni.yaml`
+		c = `sed -i 's|docker.io|` + commons.GetPrefixedRegistryURL("docker.io", keosRegistry.url, keosRegistry.ecrPullThroughCacheEnabled) + `|g' /kind/manifests/default-cni.yaml`
 
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
@@ -314,7 +314,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 
 	if privateParams.Private {
 
-		k8sRegUrl := commons.GetPrefixedRegistryURL("registry.k8s.io", keosRegistry.url, keosRegistry.awsCentralECREnabled)
+		k8sRegUrl := commons.GetPrefixedRegistryURL("registry.k8s.io", keosRegistry.url, keosRegistry.ecrPullThroughCacheEnabled)
 		c = "echo \"images:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cluster-api:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + k8sRegUrl + "/cluster-api\" >> /root/.cluster-api/clusterctl.yaml && " +
@@ -341,7 +341,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			"echo \"  infrastructure-azure/nmi:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/oss/azure/aad-pod-identity\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cert-manager:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + commons.GetPrefixedRegistryURL("quay.io", keosRegistry.url, keosRegistry.awsCentralECREnabled) + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
+			"echo \"    repository: " + commons.GetPrefixedRegistryURL("quay.io", keosRegistry.url, keosRegistry.ecrPullThroughCacheEnabled) + "/jetstack\" >> /root/.cluster-api/clusterctl.yaml "
 		_, err = commons.ExecuteCommand(n, c, 5, 3)
 		if err != nil {
 			return errors.Wrap(err, "failed to add private image registry clusterctl config")

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -179,5 +179,27 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 		return err
 	}
 
+	var awsCentralECREnabled bool
+	// check keosCluster.Spec.DockerRegistries for aws_central_ecr
+	for _, registry := range keosCluster.Spec.DockerRegistries {
+		if registry.Type == "ecr" && registry.AWSCentralECREnabled {
+			awsCentralECREnabled = true
+			break
+		}
+	}
+
+	// Handle override_vars if exists and aws_central_ecr is enabled
+	if awsCentralECREnabled {
+		overrideDir := "override_vars"
+		if info, err := os.Stat(overrideDir); err == nil && info.IsDir() {
+			overrideFile := filepath.Join(overrideDir, "aws_central_ecr_override.yml")
+			content := "aws_central_ecr_enabled: true\n"
+			err = os.WriteFile(overrideFile, []byte(content), 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -179,21 +179,21 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 		return err
 	}
 
-	var awsCentralECREnabled bool
-	// check keosCluster.Spec.DockerRegistries for aws_central_ecr
+	var ecrPullThroughCacheEnabled bool
+	// check keosCluster.Spec.DockerRegistries for ecr_pull_through_cache
 	for _, registry := range keosCluster.Spec.DockerRegistries {
-		if registry.Type == "ecr" && registry.AWSCentralECREnabled {
-			awsCentralECREnabled = true
+		if registry.Type == "ecr" && registry.ECRPullThroughCacheEnabled {
+			ecrPullThroughCacheEnabled = true
 			break
 		}
 	}
 
-	// Handle override_vars if exists and aws_central_ecr is enabled
-	if awsCentralECREnabled {
+	// Handle override_vars if exists and ecr_pull_through_cache is enabled
+	if ecrPullThroughCacheEnabled {
 		overrideDir := "override_vars"
 		if info, err := os.Stat(overrideDir); err == nil && info.IsDir() {
-			overrideFile := filepath.Join(overrideDir, "aws_central_ecr_override.yml")
-			content := "aws_central_ecr_enabled: true\n"
+			overrideFile := filepath.Join(overrideDir, "ecr_pull_through_cache_override.yml")
+			content := "ecr_pull_through_cache_enabled: true\n"
 			err = os.WriteFile(overrideFile, []byte(content), 0644)
 			if err != nil {
 				return err

--- a/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
+++ b/pkg/cluster/internal/create/actions/createworker/keosinstaller.go
@@ -27,9 +27,10 @@ import (
 
 type KEOSDescriptor struct {
 	DockerRegistry struct {
-		AuthRequired bool   `yaml:"auth_required"`
-		Type         string `yaml:"type"`
-		URL          string `yaml:"url"`
+		AuthRequired               bool   `yaml:"auth_required"`
+		Type                       string `yaml:"type"`
+		URL                        string `yaml:"url"`
+		ECRPullThroughCacheEnabled bool   `yaml:"ecr_pull_through_cache_enabled,omitempty"`
 	} `yaml:"docker_registry"`
 	HelmRepository struct {
 		AuthRequired bool   `yaml:"auth_required"`
@@ -97,6 +98,7 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 			keosDescriptor.DockerRegistry.URL = registry.URL
 			keosDescriptor.DockerRegistry.AuthRequired = registry.AuthRequired
 			keosDescriptor.DockerRegistry.Type = registry.Type
+			keosDescriptor.DockerRegistry.ECRPullThroughCacheEnabled = registry.ECRPullThroughCacheEnabled
 		}
 	}
 
@@ -177,28 +179,6 @@ func createKEOSDescriptor(keosCluster commons.KeosCluster, storageClass string) 
 	err = os.WriteFile("keos.yaml", []byte(keosYAMLData), 0644)
 	if err != nil {
 		return err
-	}
-
-	var ecrPullThroughCacheEnabled bool
-	// check keosCluster.Spec.DockerRegistries for ecr_pull_through_cache
-	for _, registry := range keosCluster.Spec.DockerRegistries {
-		if registry.Type == "ecr" && registry.ECRPullThroughCacheEnabled {
-			ecrPullThroughCacheEnabled = true
-			break
-		}
-	}
-
-	// Handle override_vars if exists and ecr_pull_through_cache is enabled
-	if ecrPullThroughCacheEnabled {
-		overrideDir := "override_vars"
-		if info, err := os.Stat(overrideDir); err == nil && info.IsDir() {
-			overrideFile := filepath.Join(overrideDir, "ecr_pull_through_cache_override.yml")
-			content := "ecr_pull_through_cache_enabled: true\n"
-			err = os.WriteFile(overrideFile, []byte(content), 0644)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -84,6 +84,7 @@ type ChartsDictionary struct {
 type PrivateParams struct {
 	KeosCluster commons.KeosCluster
 	KeosRegUrl  string
+	CentralECR  bool
 	Private     bool
 	HelmPrivate bool
 }
@@ -160,6 +161,7 @@ type helmRepository struct {
 type calicoHelmParams struct {
 	Spec           commons.KeosSpec
 	KeosRegUrl     string
+	QuayRegUrl     string
 	Private        bool
 	IsNetPolEngine bool
 	Annotations    map[string]string
@@ -168,6 +170,7 @@ type calicoHelmParams struct {
 type commonHelmParams struct {
 	KeosRegUrl string
 	Private    bool
+	CentralECR bool
 }
 
 type cloudControllerHelmParams struct {
@@ -440,6 +443,12 @@ func (p *Provider) deployCertManager(n nodes.Node, keosRegistryUrl string, kubec
 	certManagerHelmParams := commonHelmParams{
 		KeosRegUrl: keosRegistryUrl,
 		Private:    privateParams.Private,
+		CentralECR: privateParams.CentralECR,
+	}
+
+	// if central ecr is enabled add suffix to the image
+	if privateParams.CentralECR {
+		certManagerHelmParams.KeosRegUrl = commons.GetPrefixedRegistryURL("quay.io", privateParams.KeosRegUrl, privateParams.CentralECR)
 	}
 	certManagerHelmValues, err := getManifest("common", "cert-manager-helm-values.tmpl", majorVersion, certManagerHelmParams)
 	if err != nil {
@@ -694,7 +703,8 @@ func installCalico(n nodes.Node, k string, privateParams PrivateParams, isNetPol
 
 	calicoHelmParams := calicoHelmParams{
 		Spec:           keosCluster.Spec,
-		KeosRegUrl:     privateParams.KeosRegUrl,
+		KeosRegUrl:     commons.GetPrefixedRegistryURL("docker.io", privateParams.KeosRegUrl, privateParams.CentralECR),
+		QuayRegUrl:     commons.GetPrefixedRegistryURL("quay.io", privateParams.KeosRegUrl, privateParams.CentralECR),
 		Private:        privateParams.Private,
 		IsNetPolEngine: isNetPolEngine,
 		Annotations: map[string]string{
@@ -702,6 +712,10 @@ func installCalico(n nodes.Node, k string, privateParams PrivateParams, isNetPol
 		},
 	}
 
+	// if CentralECR is enabled add suffix to the image
+	if privateParams.CentralECR {
+		privateParams.KeosRegUrl = commons.GetPrefixedRegistryURL("quay.io", privateParams.KeosRegUrl, privateParams.CentralECR)
+	}
 	// Generate the calico helm values
 	calicoHelmValues, err := getManifest("common", "tigera-operator-helm-values.tmpl", majorVersion, calicoHelmParams)
 
@@ -756,6 +770,10 @@ func deployClusterAutoscaler(n nodes.Node, chartsList map[string]commons.ChartEn
 		clusterAutoscalerHelmReleaseParams.ChartRepoRef = "cluster-autoscaler"
 	}
 
+	// if Central ECR is enabled add suffix to the image
+	if privateParams.CentralECR {
+		privateParams.KeosRegUrl = commons.GetPrefixedRegistryURL("registry.k8s.io", privateParams.KeosRegUrl, privateParams.CentralECR)
+	}
 	helmValuesCA, err := getManifest("common", "cluster-autoscaler-helm-values.tmpl", majorVersion, privateParams)
 	if err != nil {
 		return errors.Wrap(err, "failed to get CA helm values")
@@ -826,6 +844,11 @@ func configureFlux(n nodes.Node, k string, privateParams PrivateParams, helmRepo
 		if err != nil {
 			return errors.Wrap(err, "failed to deploy Flux2 azure pod identity exception")
 		}
+	}
+
+	// if Central ECR is enabled add suffix to the image
+	if privateParams.CentralECR {
+		fluxHelmParams.KeosRegUrl = commons.GetPrefixedRegistryURL("ghcr.io", privateParams.KeosRegUrl, privateParams.CentralECR)
 	}
 
 	// Generate the flux helm values

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
@@ -78,7 +78,7 @@ resources: {}
 # Image and registry configuration for the tigera/operator pod.
 tigeraOperator:
 {{- if $.Private }}
-  registry: {{ $.KeosRegUrl }}
+  registry: {{ $.QuayRegUrl }}
 {{- else }}
   registry: quay.io
 {{- end }}

--- a/pkg/cluster/internal/providers/docker/stratio/upgrade/Dockerfile
+++ b/pkg/cluster/internal/providers/docker/stratio/upgrade/Dockerfile
@@ -107,6 +107,7 @@ RUN echo 'alias k="kubectl"' >> ~/.bash_aliases \
 COPY ${UPGRADE_DIR}/templates /upgrade/templates
 COPY ${UPGRADE_DIR}/files /upgrade/files
 COPY ${UPGRADE_DIR}/upgrade-provisioner.py /upgrade
+COPY ${UPGRADE_DIR}/ecr_pull_through.py /upgrade
 COPY ${UPGRADE_DIR}/requirements.txt /upgrade
 
 # Install Python dependencies

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -36,6 +36,14 @@ var (
 	capg_version = "1.6.1-0.3.1"
 )
 
+const (
+	DefaultDockerhubPrefix = "/dockerhub"
+	DefaultEcrpublicPrefix = "/ecrpublic"
+	DefaultGhcrPrefix      = "/ghcr"
+	DefaultK8sPrefix       = "/k8s"
+	DefaultQuayPrefix      = "/quay"
+)
+
 type Resource struct {
 	APIVersion string      `yaml:"apiVersion" validate:"required"`
 	Kind       string      `yaml:"kind" validate:"required"`
@@ -382,10 +390,11 @@ type DockerRegistryCredentials struct {
 }
 
 type DockerRegistry struct {
-	AuthRequired bool   `yaml:"auth_required" validate:"boolean"`
-	Type         string `yaml:"type" validate:"required,oneof='acr' 'ecr' 'gar' 'gcr' 'generic'"`
-	URL          string `yaml:"url" validate:"required"`
-	KeosRegistry bool   `yaml:"keos_registry" validate:"boolean"`
+	AuthRequired         bool   `yaml:"auth_required" validate:"boolean"`
+	Type                 string `yaml:"type" validate:"required,oneof='acr' 'ecr' 'gar' 'gcr' 'generic'"`
+	URL                  string `yaml:"url" validate:"required"`
+	KeosRegistry         bool   `yaml:"keos_registry" validate:"boolean"`
+	AWSCentralECREnabled bool   `yaml:"aws_central_ecr_enabled" validate:"boolean"`
 }
 
 type HelmRepositoryCredentials struct {
@@ -575,6 +584,126 @@ func (s KeosSpec) Init() KeosSpec {
 	s.Dns.ManageZone = true
 
 	return s
+}
+
+// GetPrefixedRegistryURL returns the registry URL with prefix if appropriate
+func GetPrefixedRegistryURL(originalRegistry string, baseRegistryURL string, awsCentralECREnabled bool) string {
+	if !awsCentralECREnabled || baseRegistryURL == "" {
+		return baseRegistryURL
+	}
+
+	prefix := ""
+	switch {
+	case strings.Contains(originalRegistry, "docker.io"):
+		prefix = DefaultDockerhubPrefix
+	case strings.Contains(originalRegistry, "public.ecr.aws"):
+		prefix = DefaultEcrpublicPrefix
+	case strings.Contains(originalRegistry, "ghcr.io"):
+		prefix = DefaultGhcrPrefix
+	case strings.Contains(originalRegistry, "quay.io"):
+		prefix = DefaultQuayPrefix
+	case strings.Contains(originalRegistry, "k8s.io"):
+		prefix = DefaultK8sPrefix
+	}
+
+	return baseRegistryURL + prefix
+}
+
+// Validator for WorkloadPool field
+func workloadPoolValidator(fl validator.FieldLevel) bool {
+	value := fl.Field().String()
+
+	if value == "" {
+		return true // omitempty
+	}
+
+	// Must match "<projectid>.svc.id.goog"
+	parts := strings.Split(value, ".svc.id.goog")
+	if len(parts) != 2 || parts[0] == "" {
+		fmt.Printf("DEBUG workloadPool: formato inválido '%s'\n", value)
+		return false
+	}
+	return true
+}
+
+// Validator for required_if_enabled
+func requiredIfEnabledValidator(fl validator.FieldLevel) bool {
+	parent := fl.Parent()
+	enabledField := parent.FieldByName("Enabled")
+
+	if !enabledField.IsValid() || enabledField.IsNil() {
+		return true
+	}
+
+	enabled := enabledField.Elem().Bool()
+	if !enabled {
+		return true
+	}
+
+	field := fl.Field()
+
+	if !field.IsValid() || (field.Kind() == reflect.Ptr && field.IsNil()) {
+		return false
+	}
+
+	switch field.Kind() {
+	case reflect.String, reflect.Slice, reflect.Map, reflect.Array:
+		return field.Len() > 0
+	default:
+		return field.Interface() != reflect.Zero(field.Type()).Interface()
+	}
+}
+
+// Validator for ServiceAccounts field
+func gcpServiceAccountsValidator(fl validator.FieldLevel) bool {
+	serviceAccounts, ok := fl.Field().Interface().(map[string]string)
+	if !ok {
+		return false
+	}
+
+	// Get parent struct (WorkloadIdentityConfig)
+	parent := fl.Parent()
+	workloadPoolField := parent.FieldByName("WorkloadPool")
+	if !workloadPoolField.IsValid() {
+		return false
+	}
+	workloadPool := workloadPoolField.String()
+
+	var poolProjectID string
+	if workloadPool != "" {
+		parts := strings.Split(workloadPool, ".svc.id.goog")
+		if len(parts) == 2 && parts[0] != "" {
+			poolProjectID = parts[0]
+		}
+	}
+
+	for _, saEmail := range serviceAccounts {
+		// 1. Format check
+		if !strings.HasSuffix(saEmail, ".iam.gserviceaccount.com") {
+			return false
+		}
+		parts := strings.Split(saEmail, "@")
+		if len(parts) != 2 {
+			return false
+		}
+
+		// 2. Consistency check
+		if poolProjectID != "" {
+			// Extract project ID from email: <sa-name>@<project-id>.iam.gserviceaccount.com
+			domainParts := strings.Split(parts[1], ".iam.gserviceaccount.com")
+			if len(domainParts) < 1 {
+				return false
+			}
+			saProjectID := domainParts[0]
+
+			if saProjectID != poolProjectID {
+				fmt.Printf("ERROR: SA MISMATCH - saProjectID='%s' not equal to poolProjectID='%s'\n", saProjectID, poolProjectID)
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 // Read descriptor file

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -394,7 +394,7 @@ type DockerRegistry struct {
 	Type                 string `yaml:"type" validate:"required,oneof='acr' 'ecr' 'gar' 'gcr' 'generic'"`
 	URL                  string `yaml:"url" validate:"required"`
 	KeosRegistry         bool   `yaml:"keos_registry" validate:"boolean"`
-	AWSCentralECREnabled bool   `yaml:"aws_central_ecr_enabled" validate:"boolean"`
+	ECRPullThroughCacheEnabled bool   `yaml:"ecr_pull_through_cache_enabled" validate:"boolean"`
 }
 
 type HelmRepositoryCredentials struct {
@@ -587,8 +587,8 @@ func (s KeosSpec) Init() KeosSpec {
 }
 
 // GetPrefixedRegistryURL returns the registry URL with prefix if appropriate
-func GetPrefixedRegistryURL(originalRegistry string, baseRegistryURL string, awsCentralECREnabled bool) string {
-	if !awsCentralECREnabled || baseRegistryURL == "" {
+func GetPrefixedRegistryURL(originalRegistry string, baseRegistryURL string, ecrPullThroughCacheEnabled bool) string {
+	if !ecrPullThroughCacheEnabled || baseRegistryURL == "" {
 		return baseRegistryURL
 	}
 

--- a/pkg/commons/cluster_test.go
+++ b/pkg/commons/cluster_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commons
+
+import (
+	"testing"
+)
+
+func TestGetPrefixedRegistryURL(t *testing.T) {
+	baseURL := "123456789.dkr.ecr.eu-west-1.amazonaws.com"
+
+	tests := []struct {
+		name                 string
+		originalRegistry     string
+		baseRegistryURL      string
+		awsCentralECREnabled bool
+		expected             string
+	}{
+		// CentralECR enabled — all 5 known registry mappings
+		{
+			name:                 "docker.io maps to /dockerhub suffix",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultDockerhubPrefix,
+		},
+		{
+			name:                 "public.ecr.aws maps to /ecrpublic suffix",
+			originalRegistry:     "public.ecr.aws",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultEcrpublicPrefix,
+		},
+		{
+			name:                 "ghcr.io maps to /ghcr suffix",
+			originalRegistry:     "ghcr.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultGhcrPrefix,
+		},
+		{
+			name:                 "quay.io maps to /quay suffix",
+			originalRegistry:     "quay.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultQuayPrefix,
+		},
+		{
+			name:                 "k8s.io maps to /k8s suffix",
+			originalRegistry:     "k8s.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultK8sPrefix,
+		},
+		// registry.k8s.io also matches the k8s.io case via strings.Contains
+		{
+			name:                 "registry.k8s.io maps to /k8s suffix via strings.Contains",
+			originalRegistry:     "registry.k8s.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL + DefaultK8sPrefix,
+		},
+		// Unknown registry returns base URL unchanged
+		{
+			name:                 "unknown registry returns base URL unchanged",
+			originalRegistry:     "mcr.microsoft.com",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: true,
+			expected:             baseURL,
+		},
+		// CentralECR disabled — always returns base URL unchanged
+		{
+			name:                 "CentralECR disabled returns base URL for docker.io",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: false,
+			expected:             baseURL,
+		},
+		{
+			name:                 "CentralECR disabled returns base URL for quay.io",
+			originalRegistry:     "quay.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: false,
+			expected:             baseURL,
+		},
+		{
+			name:                 "CentralECR disabled returns base URL for registry.k8s.io",
+			originalRegistry:     "registry.k8s.io",
+			baseRegistryURL:      baseURL,
+			awsCentralECREnabled: false,
+			expected:             baseURL,
+		},
+		// Empty base URL returns empty string
+		{
+			name:                 "empty base URL returns empty string when CentralECR enabled",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      "",
+			awsCentralECREnabled: true,
+			expected:             "",
+		},
+		{
+			name:                 "empty base URL returns empty string when CentralECR disabled",
+			originalRegistry:     "docker.io",
+			baseRegistryURL:      "",
+			awsCentralECREnabled: false,
+			expected:             "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPrefixedRegistryURL(tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled)
+			if got != tt.expected {
+				t.Errorf("GetPrefixedRegistryURL(%q, %q, %v) = %q, want %q",
+					tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/commons/cluster_test.go
+++ b/pkg/commons/cluster_test.go
@@ -27,7 +27,7 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 		name                 string
 		originalRegistry     string
 		baseRegistryURL      string
-		awsCentralECREnabled bool
+		ecrPullThroughCacheEnabled bool
 		expected             string
 	}{
 		// CentralECR enabled — all 5 known registry mappings
@@ -35,35 +35,35 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "docker.io maps to /dockerhub suffix",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultDockerhubPrefix,
 		},
 		{
 			name:                 "public.ecr.aws maps to /ecrpublic suffix",
 			originalRegistry:     "public.ecr.aws",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultEcrpublicPrefix,
 		},
 		{
 			name:                 "ghcr.io maps to /ghcr suffix",
 			originalRegistry:     "ghcr.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultGhcrPrefix,
 		},
 		{
 			name:                 "quay.io maps to /quay suffix",
 			originalRegistry:     "quay.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultQuayPrefix,
 		},
 		{
 			name:                 "k8s.io maps to /k8s suffix",
 			originalRegistry:     "k8s.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultK8sPrefix,
 		},
 		// registry.k8s.io also matches the k8s.io case via strings.Contains
@@ -71,7 +71,7 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "registry.k8s.io maps to /k8s suffix via strings.Contains",
 			originalRegistry:     "registry.k8s.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL + DefaultK8sPrefix,
 		},
 		// Unknown registry returns base URL unchanged
@@ -79,7 +79,7 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "unknown registry returns base URL unchanged",
 			originalRegistry:     "mcr.microsoft.com",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             baseURL,
 		},
 		// CentralECR disabled — always returns base URL unchanged
@@ -87,21 +87,21 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "CentralECR disabled returns base URL for docker.io",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             baseURL,
 		},
 		{
 			name:                 "CentralECR disabled returns base URL for quay.io",
 			originalRegistry:     "quay.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             baseURL,
 		},
 		{
 			name:                 "CentralECR disabled returns base URL for registry.k8s.io",
 			originalRegistry:     "registry.k8s.io",
 			baseRegistryURL:      baseURL,
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             baseURL,
 		},
 		// Empty base URL returns empty string
@@ -109,24 +109,24 @@ func TestGetPrefixedRegistryURL(t *testing.T) {
 			name:                 "empty base URL returns empty string when CentralECR enabled",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      "",
-			awsCentralECREnabled: true,
+			ecrPullThroughCacheEnabled: true,
 			expected:             "",
 		},
 		{
 			name:                 "empty base URL returns empty string when CentralECR disabled",
 			originalRegistry:     "docker.io",
 			baseRegistryURL:      "",
-			awsCentralECREnabled: false,
+			ecrPullThroughCacheEnabled: false,
 			expected:             "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetPrefixedRegistryURL(tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled)
+			got := GetPrefixedRegistryURL(tt.originalRegistry, tt.baseRegistryURL, tt.ecrPullThroughCacheEnabled)
 			if got != tt.expected {
 				t.Errorf("GetPrefixedRegistryURL(%q, %q, %v) = %q, want %q",
-					tt.originalRegistry, tt.baseRegistryURL, tt.awsCentralECREnabled, got, tt.expected)
+					tt.originalRegistry, tt.baseRegistryURL, tt.ecrPullThroughCacheEnabled, got, tt.expected)
 			}
 		})
 	}

--- a/scripts/ecr_pull_through.py
+++ b/scripts/ecr_pull_through.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+##############################################################
+# Author: Stratio Clouds <clouds-integration@stratio.com>    #
+# Purpose: ECR pull-through cache migration                  #
+#   prepare - Upgrade cluster-operator + enable pull-through #
+#   migrate - Migrate cloud-provisioner components           #
+##############################################################
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from urllib.parse import urlparse
+
+from ansible_vault import Vault
+
+kubectl = ""
+helm = ""
+
+
+# ── Utilities ────────────────────────────────────────────────────────────────
+
+def run_command(command, allow_errors=False, retries=3, retry_delay=2):
+    attempts = 0
+    while attempts <= retries:
+        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        if result.returncode == 0:
+            return result.stdout, result.stderr
+        if allow_errors:
+            return result.stdout, result.stderr
+        attempts += 1
+        if attempts > retries:
+            raise Exception(f"Error executing '{command}' after {retries + 1} attempts: {result.stderr}")
+        time.sleep(retry_delay)
+
+
+def configure_aws_credentials(vault_secrets_data):
+    print("[INFO] Configuring AWS CLI credentials", end=" ", flush=True)
+
+    aws_creds = vault_secrets_data['secrets']['aws']['credentials']
+    os.environ["AWS_PAGER"] = ""
+    os.environ["AWS_ACCESS_KEY_ID"] = aws_creds['access_key']
+    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_creds['secret_key']
+    os.environ["AWS_DEFAULT_REGION"] = aws_creds['region']
+
+    role_arn = aws_creds.get('role_arn')
+    if role_arn:
+        result = subprocess.run(
+            ["aws", "sts", "assume-role",
+             "--role-arn", role_arn,
+             "--role-session-name", "ecr-pull-through-session"],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            print("FAILED")
+            print(result.stderr)
+            sys.exit(1)
+        creds = json.loads(result.stdout)["Credentials"]
+        os.environ["AWS_ACCESS_KEY_ID"] = creds["AccessKeyId"]
+        os.environ["AWS_SECRET_ACCESS_KEY"] = creds["SecretAccessKey"]
+        os.environ["AWS_SESSION_TOKEN"] = creds["SessionToken"]
+
+    print("OK")
+
+
+def get_keos_cluster():
+    output, _ = run_command(f"{kubectl} get keoscluster -A -o json")
+    items = json.loads(output)["items"]
+    if not items:
+        raise Exception("No KeosCluster found")
+    return items[0]
+
+
+def get_keos_registry_url(keos_cluster):
+    for registry in keos_cluster["spec"].get("docker_registries", []):
+        if registry.get("keos_registry", False):
+            return registry["url"]
+    raise Exception("No keos_registry entry found in KeosCluster spec.docker_registries")
+
+
+def get_helm_repository_url(keos_cluster):
+    try:
+        return keos_cluster["spec"]["helm_repository"]["url"]
+    except KeyError:
+        raise Exception("No helm_repository.url in KeosCluster spec")
+
+
+def ecr_registry_host(url):
+    """Extract registry hostname from an OCI or HTTPS URL."""
+    clean = url.replace("oci://", "https://") if url.startswith("oci://") else url
+    return urlparse(clean).hostname
+
+
+def ecr_login(repo_url):
+    host = ecr_registry_host(repo_url)
+    region = host.split(".")[3]  # <account>.dkr.ecr.<region>.amazonaws.com
+    run_command(
+        f"aws ecr get-login-password --region {region} | "
+        f"{helm} registry login {host} --username AWS --password-stdin"
+    )
+
+
+
+def apply_configmap(cm_json):
+    """Write ConfigMap JSON to a temp file and kubectl apply it."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tf:
+        tf.write(json.dumps(cm_json))
+        tf_path = tf.name
+    try:
+        run_command(f"{kubectl} apply -f {tf_path}")
+    finally:
+        os.unlink(tf_path)
+
+
+def wait_helmrelease_ready(release, namespace, timeout=300):
+    print(f"[INFO] Waiting for HelmRelease {release}/{namespace} to be Ready", end=" ", flush=True)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        out, _ = run_command(
+            f"{kubectl} get helmrelease {release} -n {namespace} "
+            f"-o jsonpath='{{.status.conditions[?(@.type==\"Ready\")].status}}'",
+            allow_errors=True
+        )
+        if out.strip() == "True":
+            print("OK")
+            return
+        time.sleep(10)
+    raise Exception(f"HelmRelease {release} not Ready after {timeout}s")
+
+
+def wait_keoscluster_provisioned(timeout=300):
+    print("[INFO] Waiting for KeosCluster Provisioned", end=" ", flush=True)
+    run_command(
+        f"{kubectl} wait keoscluster --all -A "
+        f"--for=jsonpath='{{.status.phase}}'=Provisioned --timeout={timeout}s"
+    )
+    print("OK")
+
+
+def set_pull_through(deploy, namespace, prefix, ecr_url):
+    out, _ = run_command(
+        f"{kubectl} get deployment {deploy} -n {namespace} "
+        f"-o jsonpath='{{.spec.template.spec.containers[0].image}}'",
+        allow_errors=True
+    )
+    img = out.strip()
+    if not img:
+        print(f"  [{namespace}/{deploy}] NOT FOUND — skip")
+        return
+    if img.startswith(f"{ecr_url}/{prefix}/"):
+        print(f"  [{namespace}/{deploy}] already pull-through — skip")
+        return
+    new_img = f"{ecr_url}/{prefix}/{img[len(ecr_url) + 1:]}"
+    run_command(f"{kubectl} set image deployment/{deploy} -n {namespace} '*={new_img}'")
+    run_command(f"{kubectl} rollout status deployment/{deploy} -n {namespace} --timeout=180s")
+    print(f"  [{namespace}/{deploy}] {img} → {new_img}")
+
+
+# ── Main flow ─────────────────────────────────────────────────────────────────
+
+def run(new_co_version):
+    keos_cluster = get_keos_cluster()
+    ecr_url = get_keos_registry_url(keos_cluster)
+    helm_repo_url = get_helm_repository_url(keos_cluster)
+    kc_name = keos_cluster["metadata"]["name"]
+    kc_ns = keos_cluster["metadata"]["namespace"]
+
+    print(f"[INFO] Cluster: {kc_name} / ECR: {ecr_url}")
+
+    # ── Phase 1: upgrade cluster-operator + enable pull-through ──────────────
+
+    print("\n--- Phase 1: cluster-operator upgrade + ecr_pull_through_cache_enabled ---\n")
+
+    print("[INFO] Detecting current cluster-operator version from ConfigMap", end=" ", flush=True)
+    out, _ = run_command(
+        f"{kubectl} get configmap 00-cluster-operator-helm-chart-default-values "
+        f"-n kube-system -o jsonpath='{{.data.values\\.yaml}}'"
+    )
+    m = re.search(r'^\s+tag:\s+(\S+)', out, re.MULTILINE)
+    if not m:
+        print("FAILED")
+        raise Exception("Cannot detect current cluster-operator tag in ConfigMap")
+    old_version = m.group(1)
+    print(f"OK ({old_version})")
+
+    if ".dkr.ecr." in helm_repo_url:
+        print("[INFO] Logging into ECR registry", end=" ", flush=True)
+        ecr_login(helm_repo_url)
+        print("OK")
+
+    print(f"[INFO] Applying CRDs from cluster-operator {new_co_version}", end=" ", flush=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_command(f"{helm} pull {helm_repo_url}/cluster-operator --version {new_co_version} -d {tmpdir}")
+        tarballs = glob.glob(f"{tmpdir}/*.tgz")
+        if not tarballs:
+            raise Exception("No chart tarball found after helm pull")
+        run_command(f"tar xzf {tarballs[0]} -C {tmpdir} cluster-operator/crds/ 2>/dev/null || true")
+        crd_files = glob.glob(f"{tmpdir}/cluster-operator/crds/*.yaml")
+        if not crd_files:
+            print("SKIP (no CRDs in chart)")
+        else:
+            for crd_file in crd_files:
+                run_command(f"{kubectl} apply -f {crd_file}")
+            print("OK")
+
+    print("[INFO] Verifying ecr_pull_through_cache_enabled field in CRD", end=" ", flush=True)
+    out, _ = run_command(
+        f"{kubectl} get crd keosclusters.installer.stratio.com "
+        f"-o jsonpath='{{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties"
+        f".docker_registries.items.properties.ecr_pull_through_cache_enabled}}'",
+        allow_errors=True
+    )
+    if "boolean" not in out:
+        print("WARN — field not present; KeosCluster patch will be silently ignored")
+    else:
+        print("OK")
+
+    print("[INFO] Updating cluster-operator image tag in ConfigMap", end=" ", flush=True)
+    cm_out, _ = run_command(
+        f"{kubectl} get configmap 00-cluster-operator-helm-chart-default-values -n kube-system -o json"
+    )
+    cm = json.loads(cm_out)
+    cm["data"]["values.yaml"] = cm["data"]["values.yaml"].replace(
+        f"tag: {old_version}", f"tag: {new_co_version}"
+    )
+    apply_configmap(cm)
+    print("OK")
+
+    print("[INFO] Patching HelmRelease cluster-operator chart version", end=" ", flush=True)
+    run_command(
+        f"{kubectl} patch helmrelease cluster-operator -n kube-system "
+        f"--type=merge -p '{{\"spec\":{{\"chart\":{{\"spec\":{{\"version\":\"{new_co_version}\"}}}}}}}}'"
+    )
+    print("OK")
+
+    print("[INFO] Forcing HelmRelease reconciliation", end=" ", flush=True)
+    ts = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    run_command(
+        f"{kubectl} annotate helmrelease cluster-operator -n kube-system "
+        f"reconcile.fluxcd.io/requestedAt={ts} --overwrite"
+    )
+    print("OK")
+
+    wait_helmrelease_ready("cluster-operator", "kube-system")
+    wait_keoscluster_provisioned()
+
+    print(f"[INFO] Patching KeosCluster {kc_name} ecr_pull_through_cache_enabled=true", end=" ", flush=True)
+    try:
+        run_command(
+            f"{kubectl} patch keoscluster {kc_name} -n {kc_ns} "
+            f"--type=json -p '[{{\"op\":\"add\","
+            f"\"path\":\"/spec/docker_registries/0/ecr_pull_through_cache_enabled\","
+            f"\"value\":true}}]'"
+        )
+    except Exception:
+        run_command(
+            f"{kubectl} patch keoscluster {kc_name} -n {kc_ns} "
+            f"--type=json -p '[{{\"op\":\"replace\","
+            f"\"path\":\"/spec/docker_registries/0/ecr_pull_through_cache_enabled\","
+            f"\"value\":true}}]'"
+        )
+    print("OK")
+
+    out, _ = run_command(
+        f"{kubectl} get keoscluster {kc_name} -n {kc_ns} "
+        f"-o jsonpath='{{.spec.docker_registries[0].ecr_pull_through_cache_enabled}}'",
+        allow_errors=True
+    )
+    if out.strip() != "true":
+        print(f"[WARN] ecr_pull_through_cache_enabled={out.strip()!r} — CRD may not have the field yet")
+    else:
+        print("[INFO] Verified ecr_pull_through_cache_enabled=true in KeosCluster")
+
+    # ── Phase 2: migrate cloud-provisioner components ─────────────────────────
+
+    print("\n--- Phase 2: migrate cloud-provisioner components to ECR pull-through ---\n")
+    print("[INFO] Flux, tigera-operator and Calico are excluded — keos upgrade already handles them.\n")
+
+    print("[INFO] CAPI controllers (k8s registry):")
+    set_pull_through("capi-controller-manager",                       "capi-system",                       "k8s", ecr_url)
+    set_pull_through("capi-kubeadm-bootstrap-controller-manager",     "capi-kubeadm-bootstrap-system",     "k8s", ecr_url)
+    set_pull_through("capi-kubeadm-control-plane-controller-manager", "capi-kubeadm-control-plane-system", "k8s", ecr_url)
+
+    print("[INFO] CAPA controller (k8s registry):")
+    set_pull_through("capa-controller-manager", "capa-system", "k8s", ecr_url)
+
+    print("[INFO] cert-manager (quay registry):")
+    for deploy in ["cert-manager", "cert-manager-cainjector", "cert-manager-webhook"]:
+        set_pull_through(deploy, "cert-manager", "quay", ecr_url)
+
+    print("[INFO] cluster-autoscaler (k8s registry):")
+    set_pull_through("cluster-autoscaler-clusterapi-cluster-autoscaler", "kube-system", "k8s", ecr_url)
+
+    print("[INFO] aws-load-balancer-controller (ecrpublic registry):")
+    set_pull_through("aws-load-balancer-controller", "kube-system", "ecrpublic", ecr_url)
+
+    print("[INFO] kube-rbac-proxy sidecar (quay registry via ConfigMap):", end=" ", flush=True)
+    old_rbac = f"{ecr_url}/kubebuilder/kube-rbac-proxy"
+    new_rbac = f"{ecr_url}/quay/brancz/kube-rbac-proxy"
+    cm_values_out, _ = run_command(
+        f"{kubectl} get configmap 00-cluster-operator-helm-chart-default-values "
+        f"-n kube-system -o jsonpath='{{.data.values\\.yaml}}'",
+        allow_errors=True
+    )
+    if new_rbac in cm_values_out:
+        print("already pull-through — skip")
+    elif old_rbac not in cm_values_out:
+        print(f"SKIP (pattern not found in ConfigMap)")
+    else:
+        cm_out, _ = run_command(
+            f"{kubectl} get configmap 00-cluster-operator-helm-chart-default-values -n kube-system -o json"
+        )
+        cm = json.loads(cm_out)
+        cm["data"]["values.yaml"] = cm["data"]["values.yaml"].replace(old_rbac, new_rbac)
+        apply_configmap(cm)
+        ts = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+        run_command(
+            f"{kubectl} annotate helmrelease cluster-operator -n kube-system "
+            f"reconcile.fluxcd.io/requestedAt={ts} --overwrite"
+        )
+        run_command(
+            f"{kubectl} rollout status deployment keoscluster-controller-manager "
+            f"-n kube-system --timeout=180s"
+        )
+        print("OK")
+
+    print("\n[OK] Migration completed.")
+    print("\nVerification — images without pull-through prefix (expected: only 602401143452/*):")
+    print(
+        f"  {kubectl} get pods -A "
+        r"-o jsonpath='{range .items[*]}{.metadata.namespace}{\"\\t\"}{.spec.containers[0].image}{\"\\n\"}{end}'"
+        r" | sort -u | grep -v 'keos/dockerhub/\|keos/ecrpublic/\|keos/ghcr/\|keos/k8s/\|keos/quay/\|keos/stratio/\|602401143452'"
+    )
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="ECR pull-through cache migration.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("-p", "--vault-password", required=True,
+                        help="Vault password for decrypting secrets.yml")
+    parser.add_argument("-s", "--secrets", default="secrets.yml",
+                        help="Vault-encrypted secrets file")
+    parser.add_argument("-k", "--kubeconfig", default="~/.kube/config",
+                        help="Kubeconfig file path (or set $KUBECONFIG)")
+    parser.add_argument("--cluster-operator", required=True,
+                        help="Target cluster-operator version (e.g. 0.5.3)")
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    kubeconfig = os.environ.get("KUBECONFIG") or os.path.expanduser(args.kubeconfig)
+    if not os.path.exists(kubeconfig):
+        print(f"[ERROR] Kubeconfig not found: {kubeconfig}")
+        sys.exit(1)
+
+    kubectl = f"kubectl --kubeconfig {kubeconfig}"
+    helm = f"helm --kubeconfig {kubeconfig}"
+
+    print("[INFO] Reading secrets file", end=" ", flush=True)
+    if not os.path.exists(args.secrets):
+        print(f"\n[ERROR] Secrets file not found: {args.secrets}")
+        sys.exit(1)
+    try:
+        vault = Vault(args.vault_password)
+        vault_secrets_data = vault.load(open(args.secrets).read())
+    except Exception as e:
+        print(f"\n[ERROR] Failed to decrypt secrets: {e}")
+        sys.exit(1)
+    print("OK")
+
+    if 'aws' not in vault_secrets_data.get('secrets', {}):
+        print("[ERROR] No AWS credentials in secrets file. ECR pull-through is only supported for AWS/EKS.")
+        sys.exit(1)
+
+    configure_aws_credentials(vault_secrets_data)
+
+    try:
+        run(args.cluster_operator)
+    except Exception as e:
+        print(f"\n[ERROR] {e}")
+        sys.exit(1)

--- a/scripts/ecr_pull_through.py
+++ b/scripts/ecr_pull_through.py
@@ -145,6 +145,42 @@ def wait_keoscluster_provisioned(timeout=300):
     print("OK")
 
 
+def migrate_workload(kind, name, namespace, prefix, ecr_url):
+    """Migrate all containers and initContainers of a workload to pull-through prefix."""
+    out, _ = run_command(
+        f"{kubectl} get {kind} {name} -n {namespace} -o json",
+        allow_errors=True
+    )
+    if not out.strip():
+        print(f"  [{namespace}/{name}] NOT FOUND — skip")
+        return
+    spec = json.loads(out)
+    pod_spec = spec.get("spec", {}).get("template", {}).get("spec", {})
+    all_containers = (
+        [("containers", c, i) for i, c in enumerate(pod_spec.get("containers") or [])] +
+        [("initContainers", c, i) for i, c in enumerate(pod_spec.get("initContainers") or [])]
+    )
+    patches = []
+    for field, container, idx in all_containers:
+        img = container.get("image", "")
+        if not img.startswith(ecr_url) or img.startswith(f"{ecr_url}/{prefix}/"):
+            continue
+        new_img = f"{ecr_url}/{prefix}/{img[len(ecr_url) + 1:]}"
+        patches.append({"op": "replace", "path": f"/spec/template/spec/{field}/{idx}/image", "value": new_img})
+        print(f"    {img} → {new_img}")
+    if not patches:
+        print(f"  [{namespace}/{name}] already pull-through — skip")
+        return
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tf:
+        tf.write(json.dumps(patches))
+        tf_path = tf.name
+    try:
+        run_command(f"{kubectl} patch {kind} {name} -n {namespace} --type=json --patch-file={tf_path}")
+    finally:
+        os.unlink(tf_path)
+    run_command(f"{kubectl} rollout status {kind}/{name} -n {namespace} --timeout=180s")
+
+
 def set_pull_through(deploy, namespace, prefix, ecr_url):
     out, _ = run_command(
         f"{kubectl} get deployment {deploy} -n {namespace} "
@@ -282,7 +318,6 @@ def run(new_co_version):
     # ── Phase 2: migrate cloud-provisioner components ─────────────────────────
 
     print("\n--- Phase 2: migrate cloud-provisioner components to ECR pull-through ---\n")
-    print("[INFO] Flux, tigera-operator and Calico are excluded — keos upgrade already handles them.\n")
 
     print("[INFO] CAPI controllers (k8s registry):")
     set_pull_through("capi-controller-manager",                       "capi-system",                       "k8s", ecr_url)
@@ -332,13 +367,51 @@ def run(new_co_version):
         )
         print("OK")
 
+    print("[INFO] Tigera operator (quay registry):")
+    migrate_workload("deployment", "tigera-operator", "tigera-operator", "quay", ecr_url)
+
+    print("[INFO] Calico (quay registry via Installation CR):", end=" ", flush=True)
+    out, _ = run_command(f"{kubectl} get installation default -o json", allow_errors=True)
+    if not out.strip():
+        print("Installation CR not found — skip")
+    else:
+        inst = json.loads(out)
+        current_path = inst.get("spec", {}).get("imagePath", "")
+        target_path = "quay/calico"
+        if current_path == target_path:
+            print("already pull-through — skip")
+        else:
+            run_command(
+                f"{kubectl} patch installation default --type=merge "
+                f"-p '{{\"spec\":{{\"imagePath\":\"{target_path}\"}}}}'"
+            )
+            print(f"OK ({current_path!r} → {target_path!r})")
+            # Wait for tigera-operator to reconcile and update the DaemonSet template
+            # before calling rollout status (which would return immediately otherwise).
+            print("[INFO] Waiting for tigera-operator to update calico-node template...", flush=True)
+            expected_prefix = f"{ecr_url}/quay/"
+            deadline = time.time() + 120
+            while time.time() < deadline:
+                ds_img, _ = run_command(
+                    f"{kubectl} get daemonset calico-node -n calico-system "
+                    f"-o jsonpath='{{.spec.template.spec.containers[0].image}}'",
+                    allow_errors=True
+                )
+                if ds_img.strip().startswith(expected_prefix):
+                    break
+                time.sleep(5)
+            else:
+                raise RuntimeError("Timeout: tigera-operator did not update calico-node template")
+            run_command(f"{kubectl} rollout status daemonset/calico-node -n calico-system --timeout=240s")
+            run_command(f"{kubectl} rollout status deployment/calico-typha -n calico-system --timeout=180s", allow_errors=True)
+            run_command(f"{kubectl} rollout status deployment/calico-kube-controllers -n calico-system --timeout=180s")
+            print("OK")
+
+    print("[INFO] Flux (ghcr registry):")
+    migrate_workload("deployment", "helm-controller",   "kube-system", "ghcr", ecr_url)
+    migrate_workload("deployment", "source-controller", "kube-system", "ghcr", ecr_url)
+
     print("\n[OK] Migration completed.")
-    print("\nVerification — images without pull-through prefix (expected: only 602401143452/*):")
-    print(
-        f"  {kubectl} get pods -A "
-        r"-o jsonpath='{range .items[*]}{.metadata.namespace}{\"\\t\"}{.spec.containers[0].image}{\"\\n\"}{end}'"
-        r" | sort -u | grep -v 'keos/dockerhub/\|keos/ecrpublic/\|keos/ghcr/\|keos/k8s/\|keos/quay/\|keos/stratio/\|602401143452'"
-    )
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/scripts/upgrade-provisioner.py
+++ b/scripts/upgrade-provisioner.py
@@ -31,7 +31,7 @@ from io import StringIO
 from urllib.parse import urlparse
 
 CLOUD_PROVISIONER = "0.17.0-0.6"
-CLUSTER_OPERATOR = "0.5.2"
+CLUSTER_OPERATOR = "0.5.3"
 CLUSTER_OPERATOR_UPGRADE_SUPPORT = "0.4.X"
 CLOUD_PROVISIONER_LAST_PREVIOUS_RELEASE = "0.17.0-0.6"
 
@@ -59,7 +59,7 @@ common_charts = {
         "repo": "https://kubernetes.github.io/autoscaler"
     },
     "cluster-operator": {
-        "version": "0.5.2",
+        "version": "0.5.3",
         "namespace": "kube-system",
         "repo": ""
     },

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -122,14 +122,14 @@ These are the required images used in the charts installed by _Stratio Cloud Pro
 | v1.32.0
 
 | *cluster-operator*
-| *0.5.2*
+| *0.5.3*
 |
 |
 
 |
 |
 | stratio-releases.repo.stratio.com/stratio/cluster-operator
-| 0.5.2
+| 0.5.3
 
 |
 |

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -122,14 +122,14 @@ Estas son las imágenes necesarias que se usan en los _charts_ instalados por _S
 | v1.32.0
 
 | *cluster-operator*
-| *0.5.2*
+| *0.5.3*
 |
 |
 
 |
 |
 | stratio-releases.repo.stratio.com/stratio/cluster-operator
-| 0.5.2
+| 0.5.3
 
 |
 |


### PR DESCRIPTION
## Summary
- Backport of `aws_central_ecr_enabled` feature (ECR central pull-through cache) from master to `branch-0.17.0-0.7`
- Cherry-pick of commit `787849f3` with conflict resolution (provider.go: kept Azure pod identity block + added CentralECR block; cluster.go: kept 0.7.x CAPI/CAPA/CAPZ versions)
- No impact on Azure or GCP deployments

## Files
- `pkg/commons/cluster.go` — `AWSCentralECREnabled` field + `GetPrefixedRegistryURL()` + prefix constants (versions kept at 0.7.x: v1.7.4/v2.5.2/v1.12.4)
- `pkg/commons/cluster_test.go` — unit tests for `GetPrefixedRegistryURL`
- `pkg/cluster/.../createworker/createworker.go` — reads flag, rewrites CNI/clusterctl URLs
- `pkg/cluster/.../createworker/keosinstaller.go` — generates `aws_central_ecr_override.yml`
- `pkg/cluster/.../createworker/provider.go` — rewrites Helm values URLs
- `pkg/cluster/.../createworker/aws.go` — LB Controller ECR public prefix
- `tigera-operator-helm-values.tmpl` — uses `QuayRegUrl` for tigera registry

## Test plan
- [ ] Create cluster with `aws_central_ecr_enabled: true` and verify prefixed URLs in generated files