### PR TITLE
[PLT-4162] Always patch KeosCluster and HelmRepository helm registry (0.7.5)

### DIFF
--- a/scripts/ecr_pull_through.py
+++ b/scripts/ecr_pull_through.py
@@ -276,20 +276,19 @@ def run(new_co_version, helm_registry_override=None):
     apply_configmap(cm)
     print("OK")
 
-    if helm_repo_url != helm_repo_url_current:
-        print(f"[INFO] Patching KeosCluster helm_repository.url to {helm_repo_url}", end=" ", flush=True)
-        run_command(
-            f"{kubectl} patch keoscluster {kc_name} -n {kc_ns} "
-            f"--type=json -p '[{{\"op\":\"replace\",\"path\":\"/spec/helm_repository/url\",\"value\":\"{helm_repo_url}\"}}]'"
-        )
-        print("OK")
+    print(f"[INFO] Patching KeosCluster helm_repository.url to {helm_repo_url}", end=" ", flush=True)
+    run_command(
+        f"{kubectl} patch keoscluster {kc_name} -n {kc_ns} "
+        f"--type=json -p '[{{\"op\":\"replace\",\"path\":\"/spec/helm_repository/url\",\"value\":\"{helm_repo_url}\"}}]'"
+    )
+    print("OK")
 
-        print("[INFO] Patching HelmRepository keos url", end=" ", flush=True)
-        run_command(
-            f"{kubectl} patch helmrepository keos -n kube-system "
-            f"--type=merge -p '{{\"spec\":{{\"url\":\"{helm_repo_url}\"}}}}'"
-        )
-        print("OK")
+    print("[INFO] Patching HelmRepository keos url", end=" ", flush=True)
+    run_command(
+        f"{kubectl} patch helmrepository keos -n kube-system "
+        f"--type=merge -p '{{\"spec\":{{\"url\":\"{helm_repo_url}\"}}}}'"
+    )
+    print("OK")
 
     print("[INFO] Patching HelmRelease cluster-operator chart version", end=" ", flush=True)
     run_command(


### PR DESCRIPTION
## Summary
- Always patch `KeosCluster spec.helm_repository.url` and `HelmRepository keos` regardless of whether the registry URL changed, fixing cases where KeosCluster spec was already updated by a previous failed run but the HelmRepository object was not.

## Test plan
- [ ] Verify HelmRepository keos is updated even when KeosCluster spec already has the target registry URL
- [ ] Verify idempotency: rerunning with same registry leaves cluster in correct state