### PR TITLE
[PLT-4161] Backport ecr_pull_through_cache_enabled to 0.17.0-0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.17.0-0.8.5 (upcoming)
+
+* [PLT-4161] Backport ecr_pull_through_cache_enabled to 0.17.0-0.8.5
+
 ## 0.17.0-0.8.4 (2026-03-25)
 
 * [Fix]  Azure image to version V2, GKE coredns version to 1.11.3, Add whisker and goldmane images to list

--- a/upgrade/resources/scripts/upgrade-provisioner.py
+++ b/upgrade/resources/scripts/upgrade-provisioner.py
@@ -913,9 +913,8 @@ def upgrade_chart(chart_name, chart_data):
         with open(release_file, 'w') as f:
             f.write(helmrelease_yaml)
 
-        run_command(f"{kubectl} apply -f {repository_file}")
-
         # We need to use --server-side and --force-conflicts flags to avoid metadata.resourceVersion conflicts
+        run_command(f"{kubectl} apply -f {repository_file} --server-side --force-conflicts")
         run_command(f"{kubectl} apply -f {release_file} -n {chart_namespace} --server-side --force-conflicts")
 
         print("OK")


### PR DESCRIPTION
<!--
Thank you for your contribution! Please make sure to provide all the information requested below.
-->

### Description
Applying the HelmRepository manifest without server-side apply caused metadata.resourceVersion conflicts when the object had been previously managed with kubectl patch instead of kubectl apply.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Related Pull Requests
- _PR number_: _brief description (e.g. "documentation")_

### How Has This Been Tested?
<!-- Describe tests run and how to reproduce. -->

### Checklist:
- [x] [PR title] Title references a Jira ticket (e.g. `[PLT-99] ...`).
- [x] [PR desc] Summary of changes included.
- [ ] [PR desc] Related PRs listed (docs, tests, etc.).
- [ ] [PR labels] Correct labels applied (release, skips, cherry-pick, AT-smoke, etc.).
- [ ] [Docs] Documentation PRs referenced if required.
- [ ] [QA] Unit test PRs referenced if required.
- [ ] Code follows project style guidelines.
- [ ] Self-review performed.

### Additional Notes
<!-- Any other relevant information. -->


[PLT-99]: https://stratio.atlassian.net/browse/PLT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ