### PR TITLE
[PLT-4162] Document ecr_pull_through_cache_enabled for 0.17.0-0.7.5

### DIFF
--- a/stratio-docs/en/modules/ROOT/pages/what-is-new.adoc
+++ b/stratio-docs/en/modules/ROOT/pages/what-is-new.adoc
@@ -1,11 +1,11 @@
 = What's new
 
-The key updates in this version of _Stratio Cloud Provisioner_ are:
+The main new features in this version of _Stratio Cloud Provisioner_ are:
 
-* Se añade compatibilidad con Kubernetes 1.32.
-* Se actualizan _cluster-operator_ (v0.5.3), Flux (v2.14.1) y Tigera Operator (v3.29.1).
-* Se añade el parámetro `ecr_pull_through_cache_enabled` en el descriptor del _cluster_ para habilitar ECR como _pull-through cache_ en entornos AWS (EKS).
+* Added support for Kubernetes 1.32.
+* Updated _cluster-operator_ (v0.5.3), Flux (v2.14.1), and Tigera Operator (v3.29.1).
+* Added the `ecr_pull_through_cache_enabled` parameter to the cluster descriptor to enable ECR as a pull-through cache in AWS (EKS) environments.
 
-== Compatibility breakage
+== Breaking changes
 
-Starting with this version, the Docker registry and the Helm repository are set to private by default. You can change this behavior in the cluster’s `ClusterConfig` object by using the `private_registry` and `private_helm_repo` attributes.
+From this version, the Docker registry and the Helm repository are configured as private by default. You can change this behavior in the cluster's `ClusterConfig` object through the `private_registry` and `private_helm_repo` attributes.

--- a/stratio-docs/en/modules/ROOT/pages/what-is-new.adoc
+++ b/stratio-docs/en/modules/ROOT/pages/what-is-new.adoc
@@ -2,8 +2,9 @@
 
 The key updates in this version of _Stratio Cloud Provisioner_ are:
 
-* Added support for Kubernetes 1.32.
-* Updated _cluster-operator_ (v0.5.2), Flux (v2.14.1), and Tigera Operator (v3.29.1).
+* Se añade compatibilidad con Kubernetes 1.32.
+* Se actualizan _cluster-operator_ (v0.5.3), Flux (v2.14.1) y Tigera Operator (v3.29.1).
+* Se añade el parámetro `ecr_pull_through_cache_enabled` en el descriptor del _cluster_ para habilitar ECR como _pull-through cache_ en entornos AWS (EKS).
 
 == Compatibility breakage
 

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -68,10 +68,11 @@ For resource group-level permissions, the recommendation is:
 *** Deployment user: `Acrpull` on `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.ContainerRegistry/registries/<acr_name>`
 *** _Control-plane_: `Acrpull` on `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.ContainerRegistry/registries/<acr_name>`
 *** _Workers_: `Acrpull` on `/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.ContainerRegistry/registries/<acr_name>`
-+
+
 * Certified operating systems
 +
 To ensure compatibility between the _control-plane_ and _worker_ nodes in unmanaged Azure environments, properly configured OS images must be used. It is recommended to generate them using the https://github.com/kubernetes-sigs/image-builder[Kubernetes Image Builder], the official tool from the Kubernetes project for creating cloud-optimized images. Refer to the https://image-builder.sigs.k8s.io/[official Image Builder documentation] to learn how to build custom images.
+
 The recommended OS is Ubuntu 22.04, which is set by default in the Azure controller.
 
 === Image considerations
@@ -365,51 +366,48 @@ scopes:
 
 === Docker repositories
 
-You must specify which Docker registries will be used during installation. This section allows configuring the registry URL, type, and whether authentication is required.
+The Docker repositories that will be used during installation must be specified. This section allows you to configure the repository URL, its type, and whether it requires authentication.
 
 [cols="1,4,2,1"]
 |===
-^|Name ^|Description ^|Example ^|Optional
+^| Name ^| Description ^| Example ^| Optional
 
-| _auth++_++required_
-| Indicates if authentication is required.
-| _false_
+| `auth_required`
+| Indicates whether the repository requires authentication.
+| `false`
 | No.
 
-| _type_
-| Docker registry type.
+| `type`
+| Docker repository type.
 | acr, ecr, gar, gcr, generic
-| No
+| No.
 
-| _url_
-| Registry URL.
+| `url`
+| Repository URL.
 | AABBCC.dkr.ecr.eu-west-1.amazonaws.com/keos
-| No
+| No.
 
-| _keos++_++registry_
-| Indicates if this registry is used for _Stratio KEOS_ images.
-| _true_
-| No (at least one must be marked _true_).
+| `keos_registry`
+| Indicates whether this repository is used for _Stratio KEOS_ images.
+| `true`
+| No. At least one repository must be marked as `keos_registry`.
 
-| _ecr++_++pull++_++through++_++cache++_++enabled_
-| Habilita el uso de ECR como _pull-through cache_ para las imágenes de _Stratio KEOS_. Solo aplica en AWS (EKS) con `type: ecr`. Debe configurarse en la instalación inicial del _cluster_.
-| _true_
-| Sí. Por defecto: _false_.
+| `ecr_pull_through_cache_enabled`
+| Enables ECR as a pull-through cache for _Stratio KEOS_ images. Only applies to AWS (EKS) with `type: ecr`. Must be configured during initial cluster installation.
+| `true`
+| Yes. Default: `false`.
 |===
 
-[NOTE]
-====
-El parámetro `ecr_pull_through_cache_enabled` es una configuración _day-0_: debes configurarlo durante la creación del _cluster_. Activarlo en un _cluster_ existente no tiene efecto sobre los _workloads_ ya desplegados.
-====
+NOTE: The `ecr_pull_through_cache_enabled` parameter is a day-0 setting: it must be configured during cluster creation. Enabling it on an existing cluster does not affect workloads already deployed.
 
-==== Pre-requisitos para `ecr_pull_through_cache_enabled`
+==== Prerequisites for `ecr_pull_through_cache_enabled`
 
-Antes de crear un _cluster_ con `ecr_pull_through_cache_enabled: true`, verifica que tu cuenta AWS cumple los siguientes requisitos:
+Before creating a cluster with `ecr_pull_through_cache_enabled: true`, verify that the AWS account meets the following requirements:
 
-* Reglas de _pull-through cache_ configuradas en Amazon ECR para los cinco _upstreams_ utilizados por _Stratio KEOS_: `registry.k8s.io`, `docker.io`, `ghcr.io`, `quay.io` y `public.ecr.aws`.
-* Permisos IAM en el _node role_: `ecr:BatchImportUpstreamImage` y `ecr:CreateRepository`.
+* Pull-through cache rules configured in Amazon ECR for the five upstreams used by _Stratio KEOS_: `registry.k8s.io`, `docker.io`, `ghcr.io`, `quay.io`, and `public.ecr.aws`.
+* IAM permissions on the node role: `ecr:BatchImportUpstreamImage` and `ecr:CreateRepository`.
 
-Si tienes `spec.security.aws.create_iam: true` en el descriptor, _Stratio Cloud Provisioner_ añade estos permisos automáticamente al crear el _cluster_. Si gestionas los recursos IAM de forma manual (`create_iam: false`) o necesitas habilitarlos en una cuenta existente, actualiza el _stack_ AWS CloudFormation con `clusterawsadm`:
+If you have `spec.security.aws.create_iam: true` in the descriptor, _Stratio Cloud Provisioner_ adds these permissions automatically when creating the cluster. If you manage IAM resources manually (`create_iam: false`) or need to enable them on an existing account, update the AWS CloudFormation stack with `clusterawsadm`:
 
 [source,bash]
 ----
@@ -772,6 +770,7 @@ This example includes:
 * Kubernetes 1.28.x.
 * Use of Docker registry of type GAR.
 * Use of Helm repository of type GAR.
+* _enable++_++secure++_++boot_ (enabled by default).
 * _nodes++_++identity_ (default node service account configurable only at create time).
 * scopes (list of access scopes for service account).
 * No DNS zone control (enabled by default).

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -390,7 +390,58 @@ You must specify which Docker registries will be used during installation. This 
 | Indicates if this registry is used for _Stratio KEOS_ images.
 | _true_
 | No (at least one must be marked _true_).
+
+| _ecr++_++pull++_++through++_++cache++_++enabled_
+| Habilita el uso de ECR como _pull-through cache_ para las imágenes de _Stratio KEOS_. Solo aplica en AWS (EKS) con `type: ecr`. Debe configurarse en la instalación inicial del _cluster_.
+| _true_
+| Sí. Por defecto: _false_.
 |===
+
+[NOTE]
+====
+El parámetro `ecr_pull_through_cache_enabled` es una configuración _day-0_: debes configurarlo durante la creación del _cluster_. Activarlo en un _cluster_ existente no tiene efecto sobre los _workloads_ ya desplegados.
+====
+
+==== Pre-requisitos para `ecr_pull_through_cache_enabled`
+
+Antes de crear un _cluster_ con `ecr_pull_through_cache_enabled: true`, verifica que tu cuenta AWS cumple los siguientes requisitos:
+
+* Reglas de _pull-through cache_ configuradas en Amazon ECR para los cinco _upstreams_ utilizados por _Stratio KEOS_: `registry.k8s.io`, `docker.io`, `ghcr.io`, `quay.io` y `public.ecr.aws`.
+* Permisos IAM en el _node role_: `ecr:BatchImportUpstreamImage` y `ecr:CreateRepository`.
+
+Si tienes `spec.security.aws.create_iam: true` en el descriptor, _Stratio Cloud Provisioner_ añade estos permisos automáticamente al crear el _cluster_. Si gestionas los recursos IAM de forma manual (`create_iam: false`) o necesitas habilitarlos en una cuenta existente, actualiza el _stack_ AWS CloudFormation con `clusterawsadm`:
+
+[source,bash]
+----
+cat > /tmp/eks.config << 'EOF'
+apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSIAMConfiguration
+spec:
+  bootstrapUser:
+    enable: false
+  eks:
+    enable: true
+    iamRoleCreation: false
+    defaultControlPlaneRole:
+        disable: false
+  controlPlane:
+    enableCSIPolicy: true
+  nodes:
+    extraPolicyAttachments:
+    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    extraStatements:
+    - Action:
+        - "ecr:BatchImportUpstreamImage"
+        - "ecr:CreateRepository"
+      Effect: Allow
+      Resource:
+        - "*"
+EOF
+
+clusterawsadm bootstrap iam create-cloudformation-stack \
+  --config /tmp/eks.config \
+  --region <region>
+----
 
 === Using `role_arn` in the credentials descriptor
 

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -88,6 +88,62 @@ Key options:
 | No
 |===
 
+== Migración a ECR _pull-through cache_ en _clusters_ existentes
+
+Si tienes un _cluster_ EKS existente y quieres activar el uso de ECR como _pull-through cache_, puedes usar el _script_ `ecr_pull_through.py`, incluido en el contenedor `cloud-provisioner-upgrade:0.7.X`.
+
+El _script_ realiza las siguientes acciones:
+
+* Actualiza _Stratio Cloud Provisioner_ al _cluster-operator_ de la versión 0.5.x.
+* Activa el campo `ecr_pull_through_cache_enabled` en el `KeosCluster`.
+* Migra las referencias de imagen de los componentes del _cluster_ (CAPI, CAPA, _cert-manager_, Flux, Calico, Tigera) para utilizar el _registry_ ECR con _pull-through_.
+
+=== Pre-requisitos
+
+Antes de ejecutar el _script_, verifica que tu cuenta AWS cumple los requisitos indicados en la sección xref:operations-manual:installation.adoc#_pre_requisitos_para_ecr_pull_through_cache_enabled[Pre-requisitos para `ecr_pull_through_cache_enabled`] del manual de instalación.
+
+=== Ejecución
+
+[source,bash]
+----
+docker run --rm -it \
+  -v <secrets.yml path>:/upgrade/secrets.yml \
+  -v <kubeconfig path>:/upgrade/.kube/config \
+  cloud-provisioner-upgrade:0.7.X \
+  python3 scripts/ecr_pull_through.py [OPTIONS]
+----
+
+Opciones principales:
+
+|===
+| _Flag_ | Descripción | Valor predeterminado | Obligatoria
+
+| `-p`, `--vault-password`
+| Archivo con la contraseña de Vault para descifrar secretos.
+| No tiene
+| Sí
+
+| `-k`, `--kubeconfig`
+| Archivo de configuración de Kubectl.
+| ~/.kube/config
+| No
+
+| `-s`, `--secrets`
+| Archivo de secretos cifrados.
+| secrets.yml
+| No
+
+| `--helm-registry`
+| URL del repositorio Helm a utilizar. Si no se indica, el _script_ muestra el valor actual del _cluster_ y permite introducir uno distinto de forma interactiva.
+| No tiene
+| No
+|===
+
+[NOTE]
+====
+Si el repositorio Helm del _cluster_ debe cambiar (por ejemplo, al migrar de un _universe_ a otro), puedes introducir la nueva URL cuando el _script_ la solicite, o indicarla directamente con `--helm-registry`. El _script_ actualiza el objeto `KeosCluster` y el `HelmRepository` de Flux para que el cambio sea efectivo de inmediato.
+====
+
 == Required structure
 
 Ensure that the working directory includes the following:

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -2,13 +2,13 @@
 
 == Description
 
-The `upgrade-provisioner.py` script automates Kubernetes cluster upgrades in the following environments:
+The `upgrade-provisioner.py` script automates the upgrade of Kubernetes clusters in the following environments:
 
 - *EKS* on AWS.
 - *Azure VMs*.
 - *GKE* on GCP.
 
-It allows you to upgrade the Kubernetes cluster version from the version installed by `cloud-provisioner 0.6.X` to the one provided by `cloud-provisioner 0.7.X`. To ensure a reproducible runtime environment, the Docker image `cloud-provisioner-upgrade` has been created, which includes the upgrade script and all necessary dependencies.
+It allows upgrading the Kubernetes cluster version from the version installed by `cloud-provisioner 0.6.X` to the one provided by `cloud-provisioner 0.7.X`. To ensure a reproducible execution environment, the `cloud-provisioner-upgrade` Docker image has been created to include the upgrade script and required dependencies.
 
 == Requirements
 
@@ -16,11 +16,11 @@ It allows you to upgrade the Kubernetes cluster version from the version install
 
 * _kubeconfig_ file with access to the cluster.
 * _secrets.yml_ file used during cluster creation.
-* Installed Docker tool, required to run the container.
+* Docker tool installed, required to run the container.
 
 === Permissions
 
-It is essential to xref:operations-manual:installation.adoc[review the documentation] to ensure that no additional permissions are required in the cluster.
+It is important to xref:operations-manual:installation.adoc[review the documentation] to ensure that no additional permissions are required on the cluster.
 
 == Running the script
 
@@ -42,23 +42,23 @@ docker run --rm -it -v <secrets.yml path>:/upgrade/secrets.yml -v <kubeconfig pa
 python3 upgrade-provisioner.py [OPTIONS]
 ----
 
-Key options:
+Main options:
 
 |===
-| Flag | Description | Default Value | Mandatory
+| Flag | Description | Default value | Required
 
 | `-p`, `--vault-password`
-| Specifies a file with the Vault password to decrypt secrets.
+| Specifies a file with the Vault password required to decrypt secrets.
 | None
 | Yes
 
 | `-y`, `--yes`
-| Skips task confirmations (automatic mode).
+| Does not require confirmation between tasks (automatic mode).
 | False
 | No
 
 | `-k`, `--kubeconfig`
-| Specifies the Kubectl configuration file to use.
+| Specifies the kubectl configuration file to use.
 | ~/.kube/config
 | No
 
@@ -67,8 +67,13 @@ Key options:
 | secrets.yml
 | No
 
+| `--enable-lb-controller`
+| Enables the load balancer controller on EKS (disabled by default).
+| False
+| No
+
 | `--disable-backup`
-| Disables backup before upgrading (enabled by default).
+| Disables the backup before upgrading (enabled by default).
 | False
 | No
 
@@ -78,7 +83,7 @@ Key options:
 | No
 
 | `--skip-k8s-intermediate-version`
-| Skips the upgrade of _workers_ to an intermediate Kubernetes version. Compatible only with EKS environments.
+| Skips upgrading workers to an intermediate Kubernetes version. Only compatible with EKS environments.
 | False
 | No
 
@@ -88,21 +93,21 @@ Key options:
 | No
 |===
 
-== Migración a ECR _pull-through cache_ en _clusters_ existentes
+== Migrating to ECR pull-through cache on existing clusters
 
-Si tienes un _cluster_ EKS existente y quieres activar el uso de ECR como _pull-through cache_, puedes usar el _script_ `ecr_pull_through.py`, incluido en el contenedor `cloud-provisioner-upgrade:0.7.X`.
+If you have an existing EKS cluster and want to enable ECR as a pull-through cache, you can use the `ecr_pull_through.py` script included in the `cloud-provisioner-upgrade:0.7.X` container.
 
-El _script_ realiza las siguientes acciones:
+The script performs the following actions:
 
-* Actualiza _Stratio Cloud Provisioner_ al _cluster-operator_ de la versión 0.5.x.
-* Activa el campo `ecr_pull_through_cache_enabled` en el `KeosCluster`.
-* Migra las referencias de imagen de los componentes del _cluster_ (CAPI, CAPA, _cert-manager_, Flux, Calico, Tigera) para utilizar el _registry_ ECR con _pull-through_.
+* Upgrades _Stratio Cloud Provisioner_ to the _cluster-operator_ version 0.5.x.
+* Enables the `ecr_pull_through_cache_enabled` field in the `KeosCluster`.
+* Migrates the image references of the cluster components (CAPI, CAPA, _cert-manager_, Flux, Calico, Tigera) to use the ECR registry with pull-through.
 
-=== Pre-requisitos
+=== Prerequisites
 
-Antes de ejecutar el _script_, verifica que tu cuenta AWS cumple los requisitos indicados en la sección xref:operations-manual:installation.adoc#_pre_requisitos_para_ecr_pull_through_cache_enabled[Pre-requisitos para `ecr_pull_through_cache_enabled`] del manual de instalación.
+Before running the script, verify that the AWS account meets the requirements listed in the xref:operations-manual:installation.adoc#_prerequisites_for_ecr_pull_through_cache_enabled[Prerequisites for `ecr_pull_through_cache_enabled`] section of the installation manual.
 
-=== Ejecución
+=== Execution
 
 [source,bash]
 ----
@@ -113,44 +118,41 @@ docker run --rm -it \
   python3 scripts/ecr_pull_through.py [OPTIONS]
 ----
 
-Opciones principales:
+Main options:
 
 |===
-| _Flag_ | Descripción | Valor predeterminado | Obligatoria
+| Flag | Description | Default value | Required
 
 | `-p`, `--vault-password`
-| Archivo con la contraseña de Vault para descifrar secretos.
-| No tiene
-| Sí
+| File with the Vault password used to decrypt secrets.
+| None.
+| Yes.
 
 | `-k`, `--kubeconfig`
-| Archivo de configuración de Kubectl.
-| ~/.kube/config
-| No
+| kubectl configuration file.
+| _~/.kube/config_
+| No.
 
 | `-s`, `--secrets`
-| Archivo de secretos cifrados.
-| secrets.yml
-| No
+| Encrypted secrets file.
+| _secrets.yml_
+| No.
 
 | `--helm-registry`
-| URL del repositorio Helm a utilizar. Si no se indica, el _script_ muestra el valor actual del _cluster_ y permite introducir uno distinto de forma interactiva.
-| No tiene
-| No
+| URL of the Helm repository to use. If not specified, the script displays the cluster's current value and lets you enter a different value interactively.
+| None.
+| No.
 |===
 
-[NOTE]
-====
-Si el repositorio Helm del _cluster_ debe cambiar (por ejemplo, al migrar de un _universe_ a otro), puedes introducir la nueva URL cuando el _script_ la solicite, o indicarla directamente con `--helm-registry`. El _script_ actualiza el objeto `KeosCluster` y el `HelmRepository` de Flux para que el cambio sea efectivo de inmediato.
-====
+NOTE: If the cluster's Helm repository needs to change (for example, when migrating from one Universe to another), you can either enter the new URL when prompted by the script or specify it directly with `--helm-registry`. The script updates the `KeosCluster` object and the Flux `HelmRepository` so that the change takes effect immediately.
 
 == Required structure
 
-Ensure that the working directory includes the following:
+Make sure the working directory includes:
 
 * `upgrade-provisioner.py`: main script.
 * `templates/`: Jinja2 templates.
 * `files/`: additional files (configurations, Helm, etc.).
 * `requirements.txt`: required dependencies.
 * `secrets.yml`: cluster credentials.
-* `.kube/`: directory containing the `kubeconfig` file.
+* `.kube/`: directory with the _kubeconfig_ file.

--- a/stratio-docs/es/modules/ROOT/pages/what-is-new.adoc
+++ b/stratio-docs/es/modules/ROOT/pages/what-is-new.adoc
@@ -4,8 +4,8 @@ Las principales novedades de esta versión de _Stratio Cloud Provisioner_ son:
 
 * Se añade compatibilidad con Kubernetes 1.32.
 * Se actualizan _cluster-operator_ (v0.5.3), Flux (v2.14.1) y Tigera Operator (v3.29.1).
-* Se añade el parámetro `ecr_pull_through_cache_enabled` en el descriptor del _cluster_ para habilitar ECR como _pull-through cache_ en entornos AWS (EKS).
+* Se añade el parámetro `ecr_pull_through_cache_enabled` al descriptor del _cluster_ para habilitar ECR como _pull-through cache_ en entornos de AWS (EKS).
 
 == Ruptura de compatibilidad
 
-A partir de esta versión, el _registry_ de Docker y el repositorio de Helm se configuran como _private_ por defecto. Puedes modificar este comportamiento desde el objeto `ClusterConfig` del _cluster_, usando los atributos `private_registry` y `private_helm_repo`.
+A partir de esta versión, el _registry_ de Docker y el repositorio de Helm se configuran como _private_ por defecto. Puedes modificar este comportamiento desde el objeto `ClusterConfig` del _cluster_ mediante los atributos `private_registry` y `private_helm_repo`.

--- a/stratio-docs/es/modules/ROOT/pages/what-is-new.adoc
+++ b/stratio-docs/es/modules/ROOT/pages/what-is-new.adoc
@@ -8,4 +8,4 @@ Las principales novedades de esta versión de _Stratio Cloud Provisioner_ son:
 
 == Ruptura de compatibilidad
 
-A partir de esta versión, el _registry_ de Docker y el repositorio de Helm se configuran como _private_ por defecto. Puedes modificar este comportamiento desde el objeto `ClusterConfig` del _cluster_ mediante los atributos `private_registry` y `private_helm_repo`.
+A partir de esta versión, el _registry_ de Docker y el repositorio de Helm se configuran como _private_ por defecto. Puedes modificar este comportamiento en el objeto `ClusterConfig` del _cluster_ mediante los atributos `private_registry` y `private_helm_repo`.

--- a/stratio-docs/es/modules/ROOT/pages/what-is-new.adoc
+++ b/stratio-docs/es/modules/ROOT/pages/what-is-new.adoc
@@ -3,7 +3,8 @@
 Las principales novedades de esta versión de _Stratio Cloud Provisioner_ son:
 
 * Se añade compatibilidad con Kubernetes 1.32.
-* Se actualizan _cluster-operator_ (v0.5.2), Flux (v2.14.1) y Tigera Operator (v3.29.1).
+* Se actualizan _cluster-operator_ (v0.5.3), Flux (v2.14.1) y Tigera Operator (v3.29.1).
+* Se añade el parámetro `ecr_pull_through_cache_enabled` en el descriptor del _cluster_ para habilitar ECR como _pull-through cache_ en entornos AWS (EKS).
 
 == Ruptura de compatibilidad
 

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -366,51 +366,48 @@ scopes:
 
 === Repositorios Docker
 
-Es necesario indicar los repositorios Docker que se utilizarán durante la instalación. Este apartado permite configurar la URL del repositorio, su tipo y si requiere autenticación.
+Es necesario indicar los repositorios de Docker que se utilizarán durante la instalación. Este apartado permite configurar la URL del repositorio, su tipo y si requiere autenticación.
 
 [cols="1,4,2,1"]
 |===
-^|Nombre ^|Descripción ^|Ejemplo ^|Opcional
+^| Nombre ^| Descripción ^| Ejemplo ^| Opcional
 
-| _auth++_++required_
+| `auth_required`
 | Indica si el repositorio requiere autenticación.
-| _false_
+| `false`
 | No.
 
-| _type_
+| `type`
 | Tipo de repositorio Docker.
 | acr, ecr, gar, gcr, generic
-| No
+| No.
 
-| _url_
+| `url`
 | URL del repositorio.
 | AABBCC.dkr.ecr.eu-west-1.amazonaws.com/keos
-| No
+| No.
 
-| _keos++_++registry_
+| `keos_registry`
 | Indica si este repositorio se utiliza para las imágenes de _Stratio KEOS_.
-| _true_
-| No. Al menos un repositorio debe estar marcado como _keos++_++registry_.
+| `true`
+| No. Al menos un repositorio debe estar marcado como `keos_registry`.
 
-| _ecr++_++pull++_++through++_++cache++_++enabled_
-| Habilita el uso de ECR como _pull-through cache_ para las imágenes de _Stratio KEOS_. Solo aplica en AWS (EKS) con `type: ecr`. Debe configurarse en la instalación inicial del _cluster_.
-| _true_
-| Sí. Por defecto: _false_.
+| `ecr_pull_through_cache_enabled`
+| Habilita el uso de ECR como _pull-through cache_ para las imágenes de _Stratio KEOS_. Solo aplica a AWS (EKS) con `type: ecr`. Debe configurarse durante la instalación inicial del _cluster_.
+| `true`
+| Sí. Por defecto: `false`.
 |===
 
-[NOTE]
-====
-El parámetro `ecr_pull_through_cache_enabled` es una configuración _day-0_: debes configurarlo durante la creación del _cluster_. Activarlo en un _cluster_ existente no tiene efecto sobre los _workloads_ ya desplegados.
-====
+NOTE: El parámetro `ecr_pull_through_cache_enabled` es una configuración _day-0_: debes configurarlo durante la creación del _cluster_. Activarlo en un _cluster_ existente no afecta a los _workloads_ ya desplegados.
 
-==== Pre-requisitos para `ecr_pull_through_cache_enabled`
+==== Prerrequisitos para `ecr_pull_through_cache_enabled`
 
-Antes de crear un _cluster_ con `ecr_pull_through_cache_enabled: true`, verifica que tu cuenta AWS cumple los siguientes requisitos:
+Antes de crear un _cluster_ con `ecr_pull_through_cache_enabled: true`, verifica que la cuenta AWS cumple los siguientes requisitos:
 
 * Reglas de _pull-through cache_ configuradas en Amazon ECR para los cinco _upstreams_ utilizados por _Stratio KEOS_: `registry.k8s.io`, `docker.io`, `ghcr.io`, `quay.io` y `public.ecr.aws`.
-* Permisos IAM en el _node role_: `ecr:BatchImportUpstreamImage` y `ecr:CreateRepository`.
+* Permisos de IAM en el _node role_: `ecr:BatchImportUpstreamImage` y `ecr:CreateRepository`.
 
-Si tienes `spec.security.aws.create_iam: true` en el descriptor, _Stratio Cloud Provisioner_ añade estos permisos automáticamente al crear el _cluster_. Si gestionas los recursos IAM de forma manual (`create_iam: false`) o necesitas habilitarlos en una cuenta existente, actualiza el _stack_ AWS CloudFormation con `clusterawsadm`:
+Si tienes `spec.security.aws.create_iam: true` en el descriptor, _Stratio Cloud Provisioner_ añade estos permisos automáticamente al crear el _cluster_. Si gestionas los recursos IAM de forma manual (`create_iam: false`) o necesitas habilitarlos en una cuenta existente, actualiza el _stack_ de AWS CloudFormation con `clusterawsadm`:
 
 [source,bash]
 ----
@@ -418,30 +415,30 @@ cat > /tmp/eks.config << 'EOF'
 apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSIAMConfiguration
 spec:
-  bootstrapUser:
-    enable: false
-  eks:
-    enable: true
-    iamRoleCreation: false
-    defaultControlPlaneRole:
-        disable: false
-  controlPlane:
-    enableCSIPolicy: true
-  nodes:
-    extraPolicyAttachments:
-    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-    extraStatements:
-    - Action:
-        - "ecr:BatchImportUpstreamImage"
-        - "ecr:CreateRepository"
-      Effect: Allow
-      Resource:
-        - "*"
+  bootstrapUser:
+    enable: false
+  eks:
+    enable: true
+    iamRoleCreation: false
+    defaultControlPlaneRole:
+        disable: false
+  controlPlane:
+    enableCSIPolicy: true
+  nodes:
+    extraPolicyAttachments:
+    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    extraStatements:
+    - Action:
+        - "ecr:BatchImportUpstreamImage"
+        - "ecr:CreateRepository"
+      Effect: Allow
+      Resource:
+        - "*"
 EOF
 
 clusterawsadm bootstrap iam create-cloudformation-stack \
-  --config /tmp/eks.config \
-  --region <region>
+  --config /tmp/eks.config \
+  --region <region>
 ----
 
 === Uso de `role_arn` en el descriptor de credenciales

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -391,7 +391,58 @@ Es necesario indicar los repositorios Docker que se utilizarán durante la insta
 | Indica si este repositorio se utiliza para las imágenes de _Stratio KEOS_.
 | _true_
 | No. Al menos un repositorio debe estar marcado como _keos++_++registry_.
+
+| _ecr++_++pull++_++through++_++cache++_++enabled_
+| Habilita el uso de ECR como _pull-through cache_ para las imágenes de _Stratio KEOS_. Solo aplica en AWS (EKS) con `type: ecr`. Debe configurarse en la instalación inicial del _cluster_.
+| _true_
+| Sí. Por defecto: _false_.
 |===
+
+[NOTE]
+====
+El parámetro `ecr_pull_through_cache_enabled` es una configuración _day-0_: debes configurarlo durante la creación del _cluster_. Activarlo en un _cluster_ existente no tiene efecto sobre los _workloads_ ya desplegados.
+====
+
+==== Pre-requisitos para `ecr_pull_through_cache_enabled`
+
+Antes de crear un _cluster_ con `ecr_pull_through_cache_enabled: true`, verifica que tu cuenta AWS cumple los siguientes requisitos:
+
+* Reglas de _pull-through cache_ configuradas en Amazon ECR para los cinco _upstreams_ utilizados por _Stratio KEOS_: `registry.k8s.io`, `docker.io`, `ghcr.io`, `quay.io` y `public.ecr.aws`.
+* Permisos IAM en el _node role_: `ecr:BatchImportUpstreamImage` y `ecr:CreateRepository`.
+
+Si tienes `spec.security.aws.create_iam: true` en el descriptor, _Stratio Cloud Provisioner_ añade estos permisos automáticamente al crear el _cluster_. Si gestionas los recursos IAM de forma manual (`create_iam: false`) o necesitas habilitarlos en una cuenta existente, actualiza el _stack_ AWS CloudFormation con `clusterawsadm`:
+
+[source,bash]
+----
+cat > /tmp/eks.config << 'EOF'
+apiVersion: bootstrap.aws.infrastructure.cluster.x-k8s.io/v1beta1
+kind: AWSIAMConfiguration
+spec:
+  bootstrapUser:
+    enable: false
+  eks:
+    enable: true
+    iamRoleCreation: false
+    defaultControlPlaneRole:
+        disable: false
+  controlPlane:
+    enableCSIPolicy: true
+  nodes:
+    extraPolicyAttachments:
+    - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    extraStatements:
+    - Action:
+        - "ecr:BatchImportUpstreamImage"
+        - "ecr:CreateRepository"
+      Effect: Allow
+      Resource:
+        - "*"
+EOF
+
+clusterawsadm bootstrap iam create-cloudformation-stack \
+  --config /tmp/eks.config \
+  --region <region>
+----
 
 === Uso de `role_arn` en el descriptor de credenciales
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -93,6 +93,62 @@ Opciones principales:
 | No
 |===
 
+== Migración a ECR _pull-through cache_ en _clusters_ existentes
+
+Si tienes un _cluster_ EKS existente y quieres activar el uso de ECR como _pull-through cache_, puedes usar el _script_ `ecr_pull_through.py`, incluido en el contenedor `cloud-provisioner-upgrade:0.7.X`.
+
+El _script_ realiza las siguientes acciones:
+
+* Actualiza _Stratio Cloud Provisioner_ al _cluster-operator_ de la versión 0.5.x.
+* Activa el campo `ecr_pull_through_cache_enabled` en el `KeosCluster`.
+* Migra las referencias de imagen de los componentes del _cluster_ (CAPI, CAPA, _cert-manager_, Flux, Calico, Tigera) para utilizar el _registry_ ECR con _pull-through_.
+
+=== Pre-requisitos
+
+Antes de ejecutar el _script_, verifica que tu cuenta AWS cumple los requisitos indicados en la sección xref:operations-manual:installation.adoc#_pre_requisitos_para_ecr_pull_through_cache_enabled[Pre-requisitos para `ecr_pull_through_cache_enabled`] del manual de instalación.
+
+=== Ejecución
+
+[source,bash]
+----
+docker run --rm -it \
+  -v <secrets.yml path>:/upgrade/secrets.yml \
+  -v <kubeconfig path>:/upgrade/.kube/config \
+  cloud-provisioner-upgrade:0.7.X \
+  python3 scripts/ecr_pull_through.py [OPTIONS]
+----
+
+Opciones principales:
+
+|===
+| _Flag_ | Descripción | Valor predeterminado | Obligatoria
+
+| `-p`, `--vault-password`
+| Archivo con la contraseña de Vault para descifrar secretos.
+| No tiene
+| Sí
+
+| `-k`, `--kubeconfig`
+| Archivo de configuración de Kubectl.
+| ~/.kube/config
+| No
+
+| `-s`, `--secrets`
+| Archivo de secretos cifrados.
+| secrets.yml
+| No
+
+| `--helm-registry`
+| URL del repositorio Helm a utilizar. Si no se indica, el _script_ muestra el valor actual del _cluster_ y permite introducir uno distinto de forma interactiva.
+| No tiene
+| No
+|===
+
+[NOTE]
+====
+Si el repositorio Helm del _cluster_ debe cambiar (por ejemplo, al migrar de un _universe_ a otro), puedes introducir la nueva URL cuando el _script_ la solicite, o indicarla directamente con `--helm-registry`. El _script_ actualiza el objeto `KeosCluster` y el `HelmRepository` de Flux para que el cambio sea efectivo de inmediato.
+====
+
 == Estructura necesaria
 
 Asegúrate de que el directorio de trabajo incluya:

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -101,21 +101,21 @@ El _script_ realiza las siguientes acciones:
 
 * Actualiza _Stratio Cloud Provisioner_ al _cluster-operator_ de la versión 0.5.x.
 * Activa el campo `ecr_pull_through_cache_enabled` en el `KeosCluster`.
-* Migra las referencias de imagen de los componentes del _cluster_ (CAPI, CAPA, _cert-manager_, Flux, Calico, Tigera) para utilizar el _registry_ ECR con _pull-through_.
+* Migra las referencias de imagen de los componentes del _cluster_ (CAPI, CAPA, _cert-manager_, Flux, Calico, Tigera) para usar el _registry_ ECR con _pull-through_.
 
-=== Pre-requisitos
+=== Prerrequisitos
 
-Antes de ejecutar el _script_, verifica que tu cuenta AWS cumple los requisitos indicados en la sección xref:operations-manual:installation.adoc#_pre_requisitos_para_ecr_pull_through_cache_enabled[Pre-requisitos para `ecr_pull_through_cache_enabled`] del manual de instalación.
+Antes de ejecutar el _script_, verifica que la cuenta de AWS cumpla los requisitos indicados en la sección xref:operations-manual:installation.adoc#_prerrequisitos_para_ecr_pull_through_cache_enabled[Prerrequisitos para `ecr_pull_through_cache_enabled`] del manual de instalación.
 
 === Ejecución
 
 [source,bash]
 ----
 docker run --rm -it \
-  -v <secrets.yml path>:/upgrade/secrets.yml \
-  -v <kubeconfig path>:/upgrade/.kube/config \
-  cloud-provisioner-upgrade:0.7.X \
-  python3 scripts/ecr_pull_through.py [OPTIONS]
+  -v <secrets.yml path>:/upgrade/secrets.yml \
+  -v <kubeconfig path>:/upgrade/.kube/config \
+  cloud-provisioner-upgrade:0.7.X \
+  python3 scripts/ecr_pull_through.py [OPTIONS]
 ----
 
 Opciones principales:
@@ -124,30 +124,27 @@ Opciones principales:
 | _Flag_ | Descripción | Valor predeterminado | Obligatoria
 
 | `-p`, `--vault-password`
-| Archivo con la contraseña de Vault para descifrar secretos.
-| No tiene
-| Sí
+| Fichero con la contraseña de Vault para descifrar secretos.
+| No tiene.
+| Sí.
 
 | `-k`, `--kubeconfig`
-| Archivo de configuración de Kubectl.
-| ~/.kube/config
-| No
+| Fichero de configuración de Kubectl.
+| _~/.kube/config_
+| No.
 
 | `-s`, `--secrets`
-| Archivo de secretos cifrados.
-| secrets.yml
-| No
+| Fichero de secretos cifrados.
+| _secrets.yml_
+| No.
 
 | `--helm-registry`
-| URL del repositorio Helm a utilizar. Si no se indica, el _script_ muestra el valor actual del _cluster_ y permite introducir uno distinto de forma interactiva.
-| No tiene
-| No
+| URL del repositorio de Helm que se utilizará. Si no se indica, el _script_ muestra el valor actual del _cluster_ y permite introducir uno distinto de forma interactiva.
+| No tiene.
+| No.
 |===
 
-[NOTE]
-====
-Si el repositorio Helm del _cluster_ debe cambiar (por ejemplo, al migrar de un _universe_ a otro), puedes introducir la nueva URL cuando el _script_ la solicite, o indicarla directamente con `--helm-registry`. El _script_ actualiza el objeto `KeosCluster` y el `HelmRepository` de Flux para que el cambio sea efectivo de inmediato.
-====
+NOTE: Si el repositorio Helm del _cluster_ debe cambiar (por ejemplo, al migrar de un Universo a otro), puedes introducir la nueva URL cuando el _script_ la solicite o indicarla directamente con `--helm-registry`. El _script_ actualiza el objeto `KeosCluster` y el `HelmRepository` de Flux para que el cambio entre en vigor de inmediato.
 
 == Estructura necesaria
 


### PR DESCRIPTION
Documents the ecr_pull_through_cache_enabled feature backported to Stratio Cloud Provisioner 0.17.0-0.7.5.

## Changes
- `installation.adoc` (ES + EN): new field in Docker repositories table + prerequisites block (IAM permissions, CloudFormation stack update, day-0 limitation)
- `upgrade.adoc` (ES + EN): new section documenting the `ecr_pull_through.py` migration script for existing clusters
- `what-is-new.adoc` (ES + EN): new bullet + cluster-operator version bump v0.5.2 → v0.5.3