### PR TITLE
[PLT-4238] Deshabilitar whisker & goldmane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.17.0-0.8.5 (upcoming)
 
+* [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)
 * [Fix] Fix clusterawsadm YAML corruption when writing eks.config and add missing IAM permissions (PutRolePolicy, DeleteRolePolicy, GetRolePolicy, ListRolePolicies) to stratio-aws-temp-policy
 * [PLT-4154] Downgrade Calico v3.31.5→v3.30.2 and FluxCD flux-cli v2.8.7→v2.7.5 for compatibility
 * [PLT-4154] Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2 (flux-cli v2.7.5), cluster-operator 0.6.2

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
@@ -95,3 +95,7 @@ tolerations:
 kubernetesServiceEndpoint:
   host: ""
   port: "6443"
+whisker:
+  enabled: {{ $.Spec.Calico.ObservabilityEnabled }}
+goldmane:
+  enabled: {{ $.Spec.Calico.ObservabilityEnabled }}

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -157,6 +157,12 @@ type KeosSpec struct {
 	WorkerNodes WorkerNodes `yaml:"worker_nodes" validate:"required,dive"`
 
 	ClusterConfigRef ClusterConfigRef `yaml:"cluster_config_ref,omitempty" validate:"dive"`
+
+	Calico Calico `yaml:"calico,omitempty"`
+}
+
+type Calico struct {
+	ObservabilityEnabled bool `yaml:"observability_enabled,omitempty" validate:"boolean"`
 }
 
 type ControlPlane struct {


### PR DESCRIPTION
## Summary

- Add `calico.observability_enabled` boolean field to `KeosSpec` (default: `false`)
- Drive `whisker.enabled` and `goldmane.enabled` Helm values from that single field — both components are always toggled together
- With the default (`false`), neither Whisker nor Goldmane CRs are created by the tigera-operator Helm chart, so no pods are deployed

## Validation

Tested on eks-cl03 (EKS, eu-west-1, Calico v3.30.2):
- Fresh install with default descriptor (no `calico:` section) → `kubectl get pods -n calico-system | grep -E 'whisker|goldmane'` returns empty
- All HelmReleases Ready; `tigera-operator@v3.30.2` reconciled correctly

## Test plan

- [x] Default install (`calico.observability_enabled` absent) → no whisker/goldmane pods
- [x] Explicit `calico.observability_enabled: true` → whisker + goldmane pods running in calico-system