### PR TITLE
[AUTO cherry-pick branch-0.17.0-0.8->master] [PLT-4238] Desh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
+<<<<<<< HEAD
 * [PLT-3963] - Adaptar cloud-provisioner a Semantic Versioning
 * [PLT-3091] - Adaptar cloud-provisioner para soportar ECR central: soportar prefijos
 * [PLT-4161] - Add ecr_pull_through.py migration script and ECR pull-through support in upgrade-provisioner
 * [PLT-4154] - Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2
+=======
+* [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)
+>>>>>>> 8623c965 ([PLT-4238] Deshabilitar whisker & goldmane (#926))
 * [Fix] Fix clusterawsadm YAML corruption when writing eks.config and add missing IAM permissions (PutRolePolicy, DeleteRolePolicy, GetRolePolicy, ListRolePolicies) to stratio-aws-temp-policy
 * [PLT-4154] Downgrade Calico v3.31.5→v3.30.2 and FluxCD flux-cli v2.8.7→v2.7.5 for compatibility
 * [PLT-4154] Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2 (flux-cli v2.7.5), cluster-operator 0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
-<<<<<<< HEAD
 * [PLT-3963] - Adaptar cloud-provisioner a Semantic Versioning
 * [PLT-3091] - Adaptar cloud-provisioner para soportar ECR central: soportar prefijos
 * [PLT-4161] - Add ecr_pull_through.py migration script and ECR pull-through support in upgrade-provisioner
 * [PLT-4154] - Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2
-=======
 * [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)
->>>>>>> 8623c965 ([PLT-4238] Deshabilitar whisker & goldmane (#926))
 * [Fix] Fix clusterawsadm YAML corruption when writing eks.config and add missing IAM permissions (PutRolePolicy, DeleteRolePolicy, GetRolePolicy, ListRolePolicies) to stratio-aws-temp-policy
 * [PLT-4154] Downgrade Calico v3.31.5→v3.30.2 and FluxCD flux-cli v2.8.7→v2.7.5 for compatibility
 * [PLT-4154] Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2 (flux-cli v2.7.5), cluster-operator 0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
+* [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)
+* [PLT-4154] - Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2
+* [PLT-4161] - Add ecr_pull_through.py migration script and ECR pull-through support in upgrade-provisioner
 * [PLT-3963] - Adaptar cloud-provisioner a Semantic Versioning
 * [PLT-3091] - Adaptar cloud-provisioner para soportar ECR central: soportar prefijos
-* [PLT-4161] - Add ecr_pull_through.py migration script and ECR pull-through support in upgrade-provisioner
-* [PLT-4154] - Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2
-* [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)
 * [Fix] Fix clusterawsadm YAML corruption when writing eks.config and add missing IAM permissions (PutRolePolicy, DeleteRolePolicy, GetRolePolicy, ListRolePolicies) to stratio-aws-temp-policy
 * [PLT-4154] Downgrade Calico v3.31.5→v3.30.2 and FluxCD flux-cli v2.8.7→v2.7.5 for compatibility
 * [PLT-4154] Fix vulnerabilities: CAPI v1.10.10, CAPA v2.9.3, CAPZ v1.21.3, Calico v3.31.5, cert-manager v1.20.2, FluxCD 2.17.2 (flux-cli v2.7.5), cluster-operator 0.6.2

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/32/tigera-operator-helm-values.tmpl
@@ -95,3 +95,7 @@ tolerations:
 kubernetesServiceEndpoint:
   host: ""
   port: "6443"
+whisker:
+  enabled: {{ $.Spec.Calico.ObservabilityEnabled }}
+goldmane:
+  enabled: {{ $.Spec.Calico.ObservabilityEnabled }}

--- a/pkg/commons/cluster.go
+++ b/pkg/commons/cluster.go
@@ -157,6 +157,12 @@ type KeosSpec struct {
 	WorkerNodes WorkerNodes `yaml:"worker_nodes" validate:"required,dive"`
 
 	ClusterConfigRef ClusterConfigRef `yaml:"cluster_config_ref,omitempty" validate:"dive"`
+
+	Calico Calico `yaml:"calico,omitempty"`
+}
+
+type Calico struct {
+	ObservabilityEnabled bool `yaml:"observability_enabled,omitempty" validate:"boolean"`
 }
 
 type ControlPlane struct {


### PR DESCRIPTION
AUTO cherry-picking [PLT-4238] Deshabilitar whisker & goldmane (#926)

Make Calico Whisker and Goldmane observability components optional via
`calico.observability_enabled` descriptor field. Defaults to false so
neither component is deployed unless explicitly enabled.

Remember to remove this branch once this PR is merged!

[PLT-4238]: https://stratio.atlassian.net/browse/PLT-4238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ