### PR TITLE
[CLOUDS] Fix rbac-proxy images - cloud-provisioner 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.17.0-0.7.5 (upcoming)
 
+* [PLT-4261] Fix kube-rbac-proxy image registry: gcr.io/kubebuilder → quay.io/brancz (cluster-operator sidecar v0.15.0 and CAPZ sidecar v0.13.1)
 * [Fix] Fix clusterawsadm YAML corruption when writing eks.config and add missing IAM permissions (PutRolePolicy, DeleteRolePolicy, GetRolePolicy, ListRolePolicies) to stratio-aws-temp-policy
 * [PLT-4162] Add ECR pull-through cache migration script; bump cluster-operator to 0.5.3
 * Remove DoAT on jenkinsfile

--- a/bin/images/azure/imagenes-capz.txt
+++ b/bin/images/azure/imagenes-capz.txt
@@ -1,4 +1,4 @@
-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+quay.io/brancz/kube-rbac-proxy:v0.13.1
 mcr.microsoft.com/k8s/azureserviceoperator:v2.4.0
 mcr.microsoft.com/oss/azure/aad-pod-identity/nmi:v1.8.14
 registry.k8s.io/cluster-api-azure/cluster-api-azure-controller:v1.12.4

--- a/bin/images/commons/imagenes-cluster-operator.txt
+++ b/bin/images/commons/imagenes-cluster-operator.txt
@@ -1,2 +1,2 @@
-gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+quay.io/brancz/kube-rbac-proxy:v0.15.0
 stratio-releases.repo.stratio.com/stratio/cluster-operator:0.5.3

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -364,6 +364,16 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 		}
 	}
 
+	if !privateParams.Private && provider.capxProvider == "azure" {
+		c = "echo \"images:\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"  infrastructure-azure/kube-rbac-proxy:\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: quay.io/brancz\" >> /root/.cluster-api/clusterctl.yaml"
+		_, err = commons.ExecuteCommand(n, c, 5, 3)
+		if err != nil {
+			return errors.Wrap(err, "failed to add kube-rbac-proxy image override for azure")
+		}
+	}
+
 	err = provider.installCAPXLocal(n, *a.clusterConfig, providerParams)
 	if err != nil {
 		return err

--- a/pkg/cluster/internal/create/actions/createworker/createworker.go
+++ b/pkg/cluster/internal/create/actions/createworker/createworker.go
@@ -337,7 +337,7 @@ func (a *action) Execute(ctx *actions.ActionContext) error {
 			"echo \"  infrastructure-azure/azureserviceoperator:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/k8s\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-azure/kube-rbac-proxy:\" >> /root/.cluster-api/clusterctl.yaml && " +
-			"echo \"    repository: " + keosRegistry.url + "/kubebuilder\" >> /root/.cluster-api/clusterctl.yaml && " +
+			"echo \"    repository: " + keosRegistry.url + "/brancz\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  infrastructure-azure/nmi:\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"    repository: " + keosRegistry.url + "/oss/azure/aad-pod-identity\" >> /root/.cluster-api/clusterctl.yaml && " +
 			"echo \"  cert-manager:\" >> /root/.cluster-api/clusterctl.yaml && " +

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -605,7 +605,7 @@ func (p *Provider) deployClusterOperator(n nodes.Node, privateParams PrivatePara
 			c += " --set app.containers.controllerManager.image.tag=" + clusterOperatorImage
 		}
 		if privateParams.Private {
-			c += " --set app.containers.kubeRbacProxy.image=" + keosRegistry.url + "/kubebuilder/kube-rbac-proxy:v0.15.0"
+			c += " --set app.containers.kubeRbacProxy.image=" + keosRegistry.url + "/brancz/kube-rbac-proxy:v0.15.0"
 		}
 		if keosCluster.Spec.InfraProvider == "azure" {
 			c += " --set secrets.azure.clientIDBase64=" + strings.Split(p.capxEnvVars[1], "AZURE_CLIENT_ID_B64=")[1] +

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
@@ -60,7 +60,6 @@
 | registry.k8s.io/etcd
 | v3.5.X
 
-
 | *azuredisk-csi-driver*
 | *v1.31.2*
 |

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
@@ -22,7 +22,7 @@
 
 |
 |
-| gcr.io/kubebuilder/kube-rbac-proxy
+| quay.io/brancz/kube-rbac-proxy
 | v0.13.1
 
 |

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -110,7 +110,6 @@ These are the required images used in the charts installed by _Stratio Cloud Pro
 | quay.io/jetstack/cert-manager-startupapicheck
 | v1.17.0
 
-
 | *cluster-autoscaler*
 | *9.46.6*
 |

--- a/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -133,7 +133,7 @@ These are the required images used in the charts installed by _Stratio Cloud Pro
 
 |
 |
-| gcr.io/kubebuilder/kube-rbac-proxy
+| quay.io/brancz/kube-rbac-proxy
 | v0.15.0
 
 | *Installed by Cluster API - CAPI Component*

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
@@ -60,7 +60,6 @@
 | registry.k8s.io/etcd
 | v3.5.X
 
-
 | *azuredisk-csi-driver*
 | *v1.31.2*
 |

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/azure-vms-images.adoc
@@ -22,7 +22,7 @@
 
 |
 |
-| gcr.io/kubebuilder/kube-rbac-proxy
+| quay.io/brancz/kube-rbac-proxy
 | v0.13.1
 
 |

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -133,7 +133,7 @@ Estas son las imágenes necesarias que se usan en los _charts_ instalados por _S
 
 |
 |
-| gcr.io/kubebuilder/kube-rbac-proxy
+| quay.io/brancz/kube-rbac-proxy
 | v0.15.0
 
 | *Installado por Cluster API - CAPI Component*

--- a/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/offline-installation/common-images.adoc
@@ -110,7 +110,6 @@ Estas son las imágenes necesarias que se usan en los _charts_ instalados por _S
 | quay.io/jetstack/cert-manager-startupapicheck
 | v1.17.0
 
-
 | *cluster-autoscaler*
 | *9.46.6*
 |


### PR DESCRIPTION
## Summary

- `provider.go`: update `--set` for cluster-operator sidecar (`kubebuilder/kube-rbac-proxy:v0.15.0` → `brancz/kube-rbac-proxy:v0.15.0`) — applies when `private_registry: true`
- `createworker.go`: update `clusterctl.yaml` override for CAPZ sidecar (`kubebuilder/kube-rbac-proxy:v0.13.1` → `brancz/kube-rbac-proxy:v0.13.1`) — applies when `private_registry: true`
- `createworker.go`: add `clusterctl.yaml` override for CAPZ sidecar pointing to `quay.io/brancz` when `private_registry: false` (Azure VMs)
- `imagenes-cluster-operator.txt`, `imagenes-capz.txt`: update source registry to `quay.io/brancz/...`
- `stratio-docs` (EN/ES): update `common-images.adoc` and `azure-vms-images.adoc`

`gcr.io/kubebuilder` was deprecated and removed. Both images (`v0.15.0` cluster-operator sidecar and `v0.13.1` CAPZ sidecar) are available at `quay.io/brancz/kube-rbac-proxy`.

## Test plan

| Scenario | Pod | Image |
|---|---|---|
| EKS `private: true` | `keoscluster-controller-manager` | ✅ `<ecr>/brancz/kube-rbac-proxy:v0.15.0` |
| EKS `private: false` | `keoscluster-controller-manager` | ✅ `quay.io/brancz/kube-rbac-proxy:v0.15.0` |
| Azure VMs `private: true` | `azureserviceoperator-controller-manager` | ✅ `<acr>/brancz/kube-rbac-proxy:v0.13.1` |
| Azure VMs `private: true` | `keoscluster-controller-manager` | ✅ `<acr>/brancz/kube-rbac-proxy:v0.15.0` |
| Azure VMs `private: false` | `azureserviceoperator-controller-manager` | ✅ `quay.io/brancz/kube-rbac-proxy:v0.13.1` |
| Azure VMs `private: false` | `keoscluster-controller-manager` | ✅ quay.io/brancz/kube-rbac-proxy:v0.15.0 |

JIRA: PLT-4261.