### PR TITLE
[PLT-coredns-downgrade] Downgrade CoreDNS: EKS v1.13.1-eksbuild.1/v1.11.4-eksbuild.2, GKE v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
-* [PLT-coredns-downgrade] Downgrade CoreDNS: EKS addon v1.13.1-eksbuild.1 (k8s 1.35), v1.11.4-eksbuild.2 (k8s 1.34); GKE image v1.13.1 (k8s 1.35)
+* [PLT-coredns-downgrade] Downgrade CoreDNS: EKS addon v1.13.1-eksbuild.1 (k8s 1.35), GKE image v1.13.1 (k8s 1.35)
 * [PLT-4247] Add Kubernetes 1.34 and 1.35 support: EKS (addons, coredns, kube-proxy), Azure VMs (cloud-provider-azure 1.35.3, azuredisk 1.34.4, azurefile 1.35.3, cluster-autoscaler 9.57.0), GKE (coredns v1.13.2); bootstrap cluster updated to kindest/node:v1.35.5
 * [PLT-4266] Bump Calico v3.30.2→v3.31.5, tigera-operator controller v1.38.5→v1.40.11, FluxCD chart 2.17.2→2.18.4 (all providers, all supported minors)
 * [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
+* [PLT-coredns-downgrade] Downgrade CoreDNS: EKS addon v1.13.1-eksbuild.1 (k8s 1.35), v1.11.4-eksbuild.2 (k8s 1.34); GKE image v1.13.1 (k8s 1.35)
 * [PLT-4247] Add Kubernetes 1.34 and 1.35 support: EKS (addons, coredns, kube-proxy), Azure VMs (cloud-provider-azure 1.35.3, azuredisk 1.34.4, azurefile 1.35.3, cluster-autoscaler 9.57.0), GKE (coredns v1.13.2); bootstrap cluster updated to kindest/node:v1.35.5
 * [PLT-4266] Bump Calico v3.30.2→v3.31.5, tigera-operator controller v1.38.5→v1.40.11, FluxCD chart 2.17.2→2.18.4 (all providers, all supported minors)
 * [PLT-4238] Make Calico Whisker and Goldmane observability components optional via `calico.observability_enabled` descriptor field (default: disabled)

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -61,7 +61,7 @@ aws:
   managed:
     addons:
       aws-ebs-csi-driver: v1.61.1-eksbuild.1
-      coredns: v1.14.3-eksbuild.2
+      coredns: v1.13.1-eksbuild.1
       kube-proxy: v1.35.3-eksbuild.11
       vpc-cni: v1.20.1-eksbuild.1
     charts:
@@ -102,4 +102,4 @@ gcp:
       infrastructure-components.yaml: 1.6.1-0.4.0
   managed:
     images:
-      coredns: v1.13.2
+      coredns: v1.13.1

--- a/docs/images/gcp/imagenes-coredns.txt
+++ b/docs/images/gcp/imagenes-coredns.txt
@@ -1,1 +1,1 @@
-registry.k8s.io/coredns/coredns:v1.13.2
+registry.k8s.io/coredns/coredns:v1.13.1

--- a/pkg/cluster/internal/create/actions/createworker/templates/gcp/35/coredns_deployment.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/gcp/35/coredns_deployment.tmpl
@@ -45,9 +45,9 @@ spec:
       containers:
       - name: coredns
         {{- if .Private }}
-        image: {{ .KeosRegUrl }}/coredns/coredns:v1.13.2
+        image: {{ .KeosRegUrl }}/coredns/coredns:v1.13.1
         {{- else }}
-        image: registry.k8s.io/coredns/coredns:v1.13.2
+        image: registry.k8s.io/coredns/coredns:v1.13.1
         {{- end }}
         imagePullPolicy: IfNotPresent
         resources:


### PR DESCRIPTION
## Summary
- k8s 1.35: `v1.14.3-eksbuild.2` → `v1.13.1-eksbuild.1`
- GKE 1.31.2 --> 1.31.1

## Test plan
- [ ] EKS k8s 1.35 — coredns addon installs as `v1.13.1-eksbuild.1`
- [ ] GKE k8s 1.35  — coredns 1.31.1