### PR TITLE
[PLT-4131] Add kubeconfig secret recovery runbooks for GKE, EKS and Azure VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
+* [PLT-4131] Add kubeconfig secret recovery runbooks for GKE (CAPG), EKS (CAPA) and Azure VMs (CAPZ/KCP) in docs/
 * [PLT-4303] Downgrade CoreDNS: EKS addon v1.13.1-eksbuild.1 (k8s 1.35), GKE image v1.13.1 (k8s 1.35)
 * [PLT-4247] Add Kubernetes 1.34 and 1.35 support: EKS (addons, coredns, kube-proxy), Azure VMs (cloud-provider-azure 1.35.3, azuredisk 1.34.4, azurefile 1.35.3, cluster-autoscaler 9.57.0), GKE (coredns v1.13.2); bootstrap cluster updated to kindest/node:v1.35.5
 * [PLT-4266] Bump Calico v3.30.2→v3.31.5, tigera-operator controller v1.38.5→v1.40.11, FluxCD chart 2.17.2→2.18.4 (all providers, all supported minors)

--- a/docs/aws/kubeconfig-secret-recovery.md
+++ b/docs/aws/kubeconfig-secret-recovery.md
@@ -1,0 +1,99 @@
+# Recovery: `<cluster>-kubeconfig` secret — EKS (CAPA)
+
+## Context
+
+When the `<cluster>-kubeconfig` secret is accidentally deleted from the cluster namespace, CAPI controllers fail in cascade with:
+
+```
+failed to retrieve kubeconfig secret for Cluster <ns>/<cluster>: Secret "<cluster>-kubeconfig" not found
+```
+
+This affects: `MachineHealthCheck`, `MachinePool`, and any controller that needs to connect to the workload cluster.
+
+## Which controller manages this secret
+
+**`capi-controller-manager` does NOT regenerate this secret.** The owner is the `AWSManagedControlPlane`, managed exclusively by `capa-controller-manager`. Restarting CAPI core has no effect.
+
+## How CAPA works internally
+
+`capa-controller-manager` regenerates the secret on every reconciliation via `reconcileKubeconfig()` in `pkg/cloud/services/eks/config.go`:
+
+- Secret **does not exist** → `createCAPIKubeconfigSecret()`: generates a presigned AWS STS token and creates the secret
+- Secret **exists** → `updateCAPIKubeconfigSecret()`: regenerates the token and overwrites
+
+The presigned STS token is short-lived and CAPA updates it automatically on every reconciliation cycle.
+
+The secret contains two data keys:
+- `value` — kubeconfig with inline token (used by CAPI controllers)
+- `relative` — kubeconfig with `tokenFile` for relative path usage
+
+`reconcileKubeconfig()` only runs if **all** the following conditions are met:
+
+| Condition | If it fails... |
+|---|---|
+| Cluster not paused | exits immediately |
+| `Cluster.Status.InfrastructureReady == true` | requeue with period |
+| `ControlPlane.Status.Ready == true` (EKS ACTIVE) | return nil, kubeconfig not reconciled |
+
+### Secret markers
+
+| Marker | Expected value |
+|---|---|
+| Namespace | `cluster-<name>` |
+| Type | `cluster.x-k8s.io/secret` |
+| Data key | `value` (and `relative`) |
+| OwnerRef kind | `AWSManagedControlPlane` |
+
+## Step 1 — Verify the secret state
+
+```bash
+kubectl get secret <cluster>-kubeconfig -n cluster-<cluster> \
+  -o jsonpath='{.data}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('OK - keys:', list(d.keys()))"
+```
+
+- Result includes `value` → go to **Step 2**
+- Not found → go to **Step 2** as well (CAPA will create it on next reconciliation)
+
+## Step 2 — Force CAPA reconciliation
+
+```bash
+AMCP_NAME=$(kubectl get awsmanagedcontrolplane -n cluster-<cluster> \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl annotate awsmanagedcontrolplane $AMCP_NAME -n cluster-<cluster> \
+  reconcile.cluster.x-k8s.io/requestedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
+```
+
+CAPA will regenerate the STS token and create/update the secret on the next reconciliation cycle.
+
+> **Note (validated in live cluster `eks-cl01`, 2026-06-24):** The controller has no watch on secrets — without the annotate, the secret is not regenerated automatically. The annotate triggers reconciliation immediately and the secret is regenerated in ~5 seconds with 3 keys: `value`, `relative`, `token-file`. The OwnerRef of the regenerated secret keeps the same `AWSManagedControlPlane` UID.
+
+> **Pre-flight:** Verify that the `AWSManagedControlPlane` is in `Ready=true` state before annotating:
+> ```bash
+> kubectl get awsmanagedcontrolplane -n cluster-<cluster>
+> ```
+> If `Ready=false`, the EKS cluster has an underlying issue that must be resolved first.
+
+## Step 3 — Verify recovery
+
+```bash
+# CAPA logs — should show "Reconciling EKS kubeconfigs"
+kubectl logs -n capa-system deploy/capa-controller-manager --since=2m \
+  | grep -E "<cluster>|kubeconfig|error" | tail -20
+
+# Confirm secret exists with key "value"
+kubectl get secret <cluster>-kubeconfig -n cluster-<cluster> \
+  -o jsonpath='{.data}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('OK - keys:', list(d.keys()))"
+# Expected: OK - keys: ['value', 'relative', 'token-file']
+
+# CAPI logs — should return 0
+kubectl logs -n capi-system deploy/capi-controller-manager --since=2m \
+  | grep "<cluster>-kubeconfig.*not found" | wc -l
+```
+
+## Additional notes
+
+- There is a second secret `<cluster>-user-kubeconfig` with an exec plugin (`aws-iam-authenticator` or `aws eks get-token`) for user access. That secret is created once and not updated — do not confuse it with this one.
+- CAPA handles the `No updates are to be performed` error from CloudFormation as a non-fatal condition — the IAM stack is already up to date.

--- a/docs/azure/kubeconfig-secret-recovery.md
+++ b/docs/azure/kubeconfig-secret-recovery.md
@@ -1,0 +1,111 @@
+# Recovery: `<cluster>-kubeconfig` secret — Azure VMs (CAPZ)
+
+## Context
+
+When the `<cluster>-kubeconfig` secret is accidentally deleted from the cluster namespace, CAPI controllers fail in cascade with:
+
+```
+failed to retrieve kubeconfig secret for Cluster <ns>/<cluster>: Secret "<cluster>-kubeconfig" not found
+```
+
+This affects: `MachineHealthCheck`, `MachinePool`, and any controller that needs to connect to the workload cluster.
+
+## Which controller manages this secret
+
+For Azure VM clusters (non-managed), the kubeconfig is **not managed by CAPZ**. It is managed by **CAPI core** via the `KubeadmControlPlane` (KCP) controller:
+
+```
+capi-kubeadm-control-plane-controller-manager
+```
+
+Restarting `capz-controller-manager` has **no effect** on the kubeconfig for Azure VM clusters.
+
+## How KubeadmControlPlane works internally
+
+Unlike GKE (token-based) and EKS (presigned token), Azure VMs use a **client certificate** signed by the cluster CA (`kubernetes-admin`, `system:masters`). The cert has a validity of ~1 year and KCP rotates it automatically when it approaches expiry.
+
+KCP does **not** regenerate the kubeconfig on every reconciliation — it creates it once and rotates when the cert is near expiry. This means a deleted secret is not recreated until the next reconciliation is triggered.
+
+`reconcileKubeconfig()` only runs if **all** the following conditions are met:
+
+| Condition | If it fails... |
+|---|---|
+| Cluster not paused | exits immediately |
+| `Cluster.Status.InfrastructureReady == true` | requeue, kubeconfig not reconciled |
+| `Cluster.Spec.ControlPlaneEndpoint.IsValid()` | returns without creating the secret |
+| Secret `<cluster>-ca` must exist | requeue after 2 minutes |
+
+### Secret markers
+
+| Marker | Expected value |
+|---|---|
+| Namespace | `cluster-<name>` |
+| Type | `cluster.x-k8s.io/secret` |
+| Data key | `value` |
+| OwnerRef kind | `KubeadmControlPlane` |
+
+## Step 1 — Verify the `<cluster>-ca` secret exists
+
+This is the critical dependency. Without it, KCP cannot regenerate the kubeconfig.
+
+```bash
+kubectl get secret <cluster>-ca -n cluster-<cluster> \
+  -o jsonpath='{.data}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('CA keys:', list(d.keys()))"
+# Expected: CA keys: ['tls.crt', 'tls.key']
+```
+
+- OK → proceed to **Step 2**
+- Not found → **critical situation** — see section below
+
+## Step 2 — Force KCP reconciliation
+
+```bash
+KCP_NAME=$(kubectl get kubeadmcontrolplane -n cluster-<cluster> \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl annotate kubeadmcontrolplane $KCP_NAME -n cluster-<cluster> \
+  reconcile.cluster.x-k8s.io/requestedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
+```
+
+KCP calls `generateKubeconfig()`, reads the `<cluster>-ca` secret, generates a new client certificate, and creates the secret. Recovery time is approximately **4 seconds**.
+
+> **Note (validated in live cluster `azure-k8s135`, 2026-06-24):** The controller has no watch on secrets — without the annotate, the secret is not regenerated automatically. The annotate triggers reconciliation immediately and the secret is regenerated in ~4 seconds. The OwnerRef of the regenerated secret keeps the same KCP UID.
+
+## Step 3 — Verify recovery
+
+```bash
+# KCP logs — should show reconciliation
+kubectl logs -n capi-kubeadm-control-plane-system \
+  deploy/capi-kubeadm-control-plane-controller-manager --since=2m \
+  | grep -E "<cluster>|kubeconfig|error" | tail -20
+
+# Confirm the secret exists with key "value"
+kubectl get secret <cluster>-kubeconfig -n cluster-<cluster> \
+  -o jsonpath='{.data}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('OK - key:', list(d.keys()))"
+# Expected: OK - key: ['value']
+
+# CAPI logs — should return 0
+kubectl logs -n capi-system deploy/capi-controller-manager --since=2m \
+  | grep "<cluster>-kubeconfig.*not found" | wc -l
+```
+
+## If `<cluster>-ca` also disappears
+
+This is a different and more critical scenario:
+
+- Without the CA private key, no new client certificates can be generated for the kubeconfig.
+- The workload cluster itself continues to function (the CA lives inside the cluster's API server).
+- Options: restore from backup, use `clusterctl move` to re-import state, or — if the workload cluster API server is reachable — extract the CA from inside using `kubeadm certs certificate-authority`.
+
+This scenario is outside the scope of this standard recovery procedure.
+
+## Rollout restart as an alternative
+
+```bash
+kubectl rollout restart deploy/capi-kubeadm-control-plane-controller-manager \
+  -n capi-kubeadm-control-plane-system
+```
+
+Works with the same gates as the annotate and affects **all clusters** managed by that KCP instance. Slower than the annotate (pod startup time). The `InfrastructureReady` and `ControlPlaneEndpoint` gates still apply.

--- a/docs/gcp/kubeconfig-secret-recovery.md
+++ b/docs/gcp/kubeconfig-secret-recovery.md
@@ -1,0 +1,155 @@
+# Recovery: `<cluster>-kubeconfig` secret — GKE (CAPG)
+
+## Context
+
+When the `<cluster>-kubeconfig` secret is accidentally deleted from the cluster namespace, CAPI controllers fail in cascade with:
+
+```
+failed to retrieve kubeconfig secret for Cluster <ns>/<cluster>: Secret "<cluster>-kubeconfig" not found
+```
+
+This affects: `MachineHealthCheck`, `MachinePool`, and any controller that needs to connect to the workload cluster.
+
+## Which controller manages this secret
+
+**`capi-controller-manager` does NOT regenerate this secret.** The owner is the `GCPManagedControlPlane`, managed exclusively by `capg-controller-manager`. Restarting CAPI core has no effect.
+
+## How CAPG works internally
+
+`capg-controller-manager` regenerates the secret on every reconciliation via `reconcileKubeconfig()` in `cloud/services/container/clusters/kubeconfig.go`:
+
+- Secret **does not exist** → `createCAPIKubeconfigSecret()`: generates a GCP token and creates the secret
+- Secret **exists** → `updateCAPIKubeconfigSecret()`: regenerates the token and overwrites
+
+The GCP token lasts **1 hour** but CAPG rotates it automatically on every reconciliation cycle.
+
+`reconcileKubeconfig()` only runs if **all** the following conditions are met:
+
+| Condition | If it fails... |
+|---|---|
+| Cluster not paused | exits immediately |
+| `GCPManagedCluster.Status.Ready == true` | requeue, kubeconfig not reconciled |
+| GKE cluster status == `RUNNING` | requeue or error depending on state |
+| No pending updates on the GKE cluster | exits after the update, kubeconfig not reconciled |
+
+### Secret markers
+
+| Marker | Expected value |
+|---|---|
+| Namespace | `cluster-<name>` |
+| Type | `cluster.x-k8s.io/secret` |
+| Data key | `value` |
+| OwnerRef kind | `GCPManagedControlPlane` |
+
+## Pre-flight: verify the GKE cluster has no pending operations
+
+```bash
+gcloud container clusters describe <cluster> \
+  --zone=<zone> --project=<project> \
+  --format='table(name,status,currentNodeVersion)' | cat
+```
+
+- `status: RUNNING` → no pending operations, proceed
+- `status: RECONCILING` / `PROVISIONING` / `UPGRADING` → operation in progress; the annotate will not work until it completes
+
+## Step 1 — Verify the secret state
+
+```bash
+kubectl get secret <cluster>-kubeconfig -n cluster-<cluster> \
+  -o jsonpath='{.data}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('OK - key:', list(d.keys()))"
+```
+
+- Result: `OK - key: ['value']` → go to **Step 2a**
+- Not found or wrong key → go to **Step 2b**
+
+## Step 2a — Force CAPG reconciliation (secret exists with key `value`)
+
+```bash
+GCP_MCP_NAME=$(kubectl get gcpmanagedcontrolplane -n cluster-<cluster> \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl annotate gcpmanagedcontrolplane $GCP_MCP_NAME -n cluster-<cluster> \
+  reconcile.cluster.x-k8s.io/requestedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
+```
+
+CAPG calls `updateCAPIKubeconfigSecret()`, generates a fresh token, and writes it to the secret. The rotation cycle is active from this point.
+
+> **Note:** The controller has no watch on secrets — without the annotate, the secret is not regenerated automatically even if the controller is running.
+
+## Step 2b — Recreate the secret from scratch (secret does not exist)
+
+```bash
+CLUSTER=<cluster>
+NAMESPACE=cluster-${CLUSTER}
+
+PROJECT=$(kubectl get gcpmanagedcontrolplane $CLUSTER -n $NAMESPACE \
+  -o jsonpath='{.spec.project}')
+LOCATION=$(kubectl get gcpmanagedcontrolplane $CLUSTER -n $NAMESPACE \
+  -o jsonpath='{.spec.location}')
+
+kubectl get secret capg-manager-bootstrap-credentials -n capg-system \
+  -o jsonpath='{.data.credentials}' | base64 -d > /tmp/capg-sa.json
+gcloud auth activate-service-account --key-file=/tmp/capg-sa.json
+TOKEN=$(gcloud auth print-access-token)
+
+ENDPOINT=$(gcloud container clusters describe $CLUSTER \
+  --zone=$LOCATION --project=$PROJECT --format='value(endpoint)')
+CA_CERT=$(gcloud container clusters describe $CLUSTER \
+  --zone=$LOCATION --project=$PROJECT \
+  --format='value(masterAuth.clusterCaCertificate)')
+
+CONTEXT="gke_${PROJECT}_${LOCATION}_${CLUSTER}"
+
+kubectl create secret generic ${CLUSTER}-kubeconfig \
+  -n $NAMESPACE \
+  --from-literal=value="$(cat <<EOF
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${CA_CERT}
+    server: https://${ENDPOINT}
+  name: ${CONTEXT}
+contexts:
+- context:
+    cluster: ${CONTEXT}
+    user: ${CONTEXT}
+  name: ${CONTEXT}
+current-context: ${CONTEXT}
+kind: Config
+preferences: {}
+users:
+- name: ${CONTEXT}
+  user:
+    token: ${TOKEN}
+EOF
+)"
+
+rm /tmp/capg-sa.json
+```
+
+After creating the secret, also run the annotate from **Step 2a** so CAPG takes ownership.
+
+## Step 3 — Verify recovery
+
+```bash
+# CAPG logs — should show successful reconciliation
+kubectl logs -n capg-system deploy/capg-controller-manager --since=2m \
+  | grep -E "<cluster>|kubeconfig|error" | tail -20
+
+# CAPI logs — should return 0
+kubectl logs -n capi-system deploy/capi-controller-manager --since=2m \
+  | grep "<cluster>-kubeconfig.*not found" | wc -l
+```
+
+## Known issues
+
+### Loop on `resourceLabels` causing stuck "no pending operations" gate
+
+CAPG does a **replace-all** of `resourceLabels` (not merge): if GKE automatically adds managed labels (e.g. `goog-gke-node-pool-provisioning-model: on-demand`), CAPG detects them as drift on every cycle and re-applies, which GKE translates into a rolling node pool replacement. Logs show `"Cluster is currently undergoing another operation"` in a loop.
+
+**Fix:** add those labels to `additional_labels` in the cluster descriptor so the state converges.
+
+### Silent error in `updateCAPIKubeconfigSecret`
+
+In `kubeconfig.go`, when the secret exists but `updateCAPIKubeconfigSecret()` fails internally, the function returns `nil` instead of the real error — the reconciliation appears successful but the update was silently skipped. Only affects the update path (secret exists), not the creation path (secret does not exist). Diagnose via logs.


### PR DESCRIPTION
## Summary

- Add recovery runbooks for the \`<cluster>-kubeconfig\` secret for all three supported providers
- Validated in live clusters: \`janr-gke1\` (GKE), \`eks-cl01\` (EKS), \`azure-k8s135\` (Azure VMs)

Documented and placed under \`docs/\` since no client has reported this as an active issue. If escalated, content can be moved to \`stratio-docs/\`.

## Runbooks added

| File | Provider | Controller | Auth |
|---|---|---|---|
| \`docs/gcp/kubeconfig-secret-recovery.md\` | GKE | CAPG / \`GCPManagedControlPlane\` | GCP token (1h) |
| \`docs/aws/kubeconfig-secret-recovery.md\` | EKS | CAPA / \`AWSManagedControlPlane\` | STS presigned token |
| \`docs/azure/kubeconfig-secret-recovery.md\` | Azure VMs | CAPZ / \`KubeadmControlPlane\` | Client cert (~1yr) |

## Recovery procedure (all providers)

\`\`\`bash
kubectl annotate <provider-controlplane-crd> <name> -n cluster-<cluster> \
  reconcile.cluster.x-k8s.io/requestedAt="\$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
\`\`\`

Recovery time: **4–7 seconds** in all three providers.

## Test plan

- [x] **GKE** (\`janr-gke1\`) — secret deleted and recovered via annotate on \`GCPManagedControlPlane\` (~7s)
\`\`\`bash
kubectl delete secret janr-gke1-kubeconfig -n cluster-janr-gke1
kubectl annotate gcpmanagedcontrolplane janr-gke1-control-plane -n cluster-janr-gke1 \
  reconcile.cluster.x-k8s.io/requestedAt="\$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
\`\`\`

- [x] **EKS** (\`eks-cl01\`) — secret deleted and recovered via annotate on \`AWSManagedControlPlane\` (~5s)
\`\`\`bash
kubectl delete secret eks-cl01-kubeconfig -n cluster-eks-cl01
kubectl annotate awsmanagedcontrolplane eks-cl01-control-plane -n cluster-eks-cl01 \
  reconcile.cluster.x-k8s.io/requestedAt="\$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
\`\`\`

- [x] **Azure VMs** (\`azure-k8s135\`) — secret deleted and recovered via annotate on \`KubeadmControlPlane\` (~4s)
\`\`\`bash
kubectl delete secret azure-k8s135-kubeconfig -n cluster-azure-k8s135
kubectl annotate kubeadmcontrolplane azure-k8s135-control-plane -n cluster-azure-k8s135 \
  reconcile.cluster.x-k8s.io/requestedAt="\$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
\`\`\`