### PR TITLE
[PLT-4264] Alinear versiones CoreDNS y Flux en cloud-provisioner para k8s 1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 0.9.0 (upcoming)
 
 * [PLT-4131] Add kubeconfig secret recovery runbooks for GKE (CAPG), EKS (CAPA) and Azure VMs (CAPZ/KCP) in docs/
+* [PLT-4264] Downgrade flux2 chart 2.18.4→2.17.2 and components (helm-controller v1.4.5, source-controller v1.7.4, kustomize-controller v1.7.3, flux-cli v2.7.5) for all providers and k8s supported minors
 * [PLT-4303] Downgrade CoreDNS: EKS addon v1.13.1-eksbuild.1 (k8s 1.35), GKE image v1.13.1 (k8s 1.35)
 * [PLT-4247] Add Kubernetes 1.34 and 1.35 support: EKS (addons, coredns, kube-proxy), Azure VMs (cloud-provider-azure 1.35.3, azuredisk 1.34.4, azurefile 1.35.3, cluster-autoscaler 9.57.0), GKE (coredns v1.13.2); bootstrap cluster updated to kindest/node:v1.35.5
 * [PLT-4266] Bump Calico v3.30.2→v3.31.5, tigera-operator controller v1.38.5→v1.40.11, FluxCD chart 2.17.2→2.18.4 (all providers, all supported minors)

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -30,10 +30,10 @@ core:
     cluster-operator:
       cluster-operator: 0.7.0-m.1
     flux:
-      flux-cli: v2.8.8
-      helm-controller: v1.5.5
-      kustomize-controller: v1.8.5
-      source-controller: v1.8.5
+      flux-cli: v2.7.5
+      helm-controller: v1.4.5
+      kustomize-controller: v1.7.3
+      source-controller: v1.7.4
     kind:
       cloud-provisioner: 0.17.0-0.8.0
       coredns: v1.13.1
@@ -47,7 +47,7 @@ core:
     cert-manager: v1.20.2
     cluster-autoscaler: 9.57.0
     cluster-operator: 0.5.2
-    flux: 2.18.4
+    flux: 2.17.2
     tigera-operator: v3.31.5
 aws:
   capa:

--- a/docs/images/commons/imagenes-flux.txt
+++ b/docs/images/commons/imagenes-flux.txt
@@ -1,4 +1,4 @@
-ghcr.io/fluxcd/flux-cli:v2.8.8
-ghcr.io/fluxcd/helm-controller:v1.5.5
-ghcr.io/fluxcd/kustomize-controller:v1.8.5
-ghcr.io/fluxcd/source-controller:v1.8.5
+ghcr.io/fluxcd/flux-cli:v2.7.5
+ghcr.io/fluxcd/helm-controller:v1.4.5
+ghcr.io/fluxcd/kustomize-controller:v1.7.3
+ghcr.io/fluxcd/source-controller:v1.7.4

--- a/pkg/cluster/internal/create/actions/createworker/provider.go
+++ b/pkg/cluster/internal/create/actions/createworker/provider.go
@@ -248,11 +248,11 @@ var commonsCharts = ChartsDictionary{
 		"35": {
 			"managed": {
 				"cert-manager": {Repository: "https://charts.jetstack.io", Version: "v1.20.2", Namespace: "cert-manager", Pull: true, Reconcile: true},
-				"flux2":        {Repository: "https://fluxcd-community.github.io/helm-charts", Version: "2.18.4", Namespace: "kube-system", Pull: true, Reconcile: true},
+				"flux2":        {Repository: "https://fluxcd-community.github.io/helm-charts", Version: "2.17.2", Namespace: "kube-system", Pull: true, Reconcile: true},
 			},
 			"unmanaged": {
 				"cert-manager": {Repository: "https://charts.jetstack.io", Version: "v1.20.2", Namespace: "cert-manager", Pull: true, Reconcile: true},
-				"flux2":        {Repository: "https://fluxcd-community.github.io/helm-charts", Version: "2.18.4", Namespace: "kube-system", Pull: true, Reconcile: true},
+				"flux2":        {Repository: "https://fluxcd-community.github.io/helm-charts", Version: "2.17.2", Namespace: "kube-system", Pull: true, Reconcile: true},
 			},
 		},
 	},

--- a/pkg/cluster/internal/create/actions/createworker/templates/common/35/flux2-helm-values.tmpl
+++ b/pkg/cluster/internal/create/actions/createworker/templates/common/35/flux2-helm-values.tmpl
@@ -1,10 +1,10 @@
 cli:
   image: {{ if $.Private }}{{ $.KeosRegUrl }}{{ else }}ghcr.io{{ end }}/fluxcd/flux-cli
-  tag: v2.8.8
+  tag: v2.7.5
 
 helmController:
   image: {{ if $.Private }}{{ $.KeosRegUrl }}{{ else }}ghcr.io{{ end }}/fluxcd/helm-controller
-  tag: v1.5.5
+  tag: v1.4.5
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: temp
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -20,7 +20,7 @@ imageReflectionController:
 
 kustomizeController:
   image: {{ if $.Private }}{{ $.KeosRegUrl }}{{ else }}ghcr.io{{ end }}/fluxcd/kustomize-controller
-  tag: v1.8.5
+  tag: v1.7.3
   container:
     additionalArgs:
       - --concurrent=50
@@ -36,7 +36,7 @@ policies:
 
 sourceController:
   image: {{ if $.Private }}{{ $.KeosRegUrl }}{{ else }}ghcr.io{{ end }}/fluxcd/source-controller
-  tag: v1.8.5
+  tag: v1.7.4
   annotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,tmp
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"


### PR DESCRIPTION
## Summary

- Downgrade flux2 chart 2.18.4 → 2.17.2 for all providers and k8s supported minors (32, 33, 34, 35)
- Downgrade flux component images: helm-controller v1.4.5, source-controller v1.7.4, kustomize-controller v1.7.3, flux-cli v2.7.5
- Fix `templates/common/35/flux2-helm-values.tmpl` image tags (were bumped to v1.5.5/v1.8.5 in PLT-4266)

CoreDNS part done in PLT-4303.

## Test plan

- [x] EKS k8s 1.35 cluster (`eks-cl02`) deployed successfully
- [x] `flux2` HelmRelease: chart version `2.17.2`, status `Ready`
- [x] helm-controller: `v1.4.5` ✓
- [x] kustomize-controller: `v1.7.3` ✓
- [x] source-controller: `v1.7.4` ✓