### PR TITLE
[clouds] Fix cloud-provisioner crash when CloudFormation stack has no updates to perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
+* [PLT-4334] Fix cloud-provisioner crash when CloudFormation stack has no updates to perform (ignore "No updates are to be performed" error from clusterawsadm as success)
 * [PLT-4131] Add kubeconfig secret recovery runbooks for GKE (CAPG), EKS (CAPA) and Azure VMs (CAPZ/KCP) in docs/
 * [PLT-4264] Downgrade flux2 chart 2.18.4→2.17.2 and components (helm-controller v1.4.5, source-controller v1.7.4, kustomize-controller v1.7.3, flux-cli v2.7.5) for all providers and k8s supported minors
 * [PLT-4303] Downgrade CoreDNS: EKS addon v1.13.1-eksbuild.1 (k8s 1.35), GKE image v1.13.1 (k8s 1.35)

--- a/pkg/cluster/internal/create/actions/createworker/aws.go
+++ b/pkg/cluster/internal/create/actions/createworker/aws.go
@@ -294,7 +294,7 @@ spec:
 	c = "clusterawsadm bootstrap iam create-cloudformation-stack --config " + eksConfigPath
 
 	_, err = commons.ExecuteCommand(n, c, 5, 3, envVars)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "No updates are to be performed") {
 		return errors.Wrap(err, "failed to run clusterawsadm")
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Ignore \`"No updates are to be performed"\` error from \`clusterawsadm\` when updating the CloudFormation stack — this response means the stack is already in the desired state, not a failure.
- Fixes spurious crash at \`[CAPA] Ensuring IAM security\` step on accounts where the CF stack was already bootstrapped.

## Ticket

[PLT-4334](https://stratio.atlassian.net/browse/PLT-4334)

## Test plan

- [ ] Deploy EKS cluster with \`create_iam: true\` on account where CF stack already exists → step passes without error
- [ ] Deploy EKS cluster with \`create_iam: true\` on account where CF stack needs update → update succeeds and legitimate errors are still surfaced

[PLT-4334]: https://stratio.atlassian.net/browse/PLT-4334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ