### PR TITLE
[PLT-4103] Documentación MachinePools + permisos EKS para nodegroups gestionados

### DIFF
--- a/stratio-docs/en/modules/ROOT/assets/attachments/stratio-aws-temp-policy.json
+++ b/stratio-docs/en/modules/ROOT/assets/attachments/stratio-aws-temp-policy.json
@@ -12,6 +12,7 @@
                 "iam:CreateInstanceProfile",
                 "iam:CreatePolicy",
                 "iam:CreatePolicyVersion",
+                "iam:DeletePolicyVersion",
                 "iam:CreateRole",
                 "iam:CreateUser",
                 "iam:DeleteGroup",

--- a/stratio-docs/en/modules/ROOT/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/en/modules/ROOT/assets/attachments/stratio-eks-policy.json
@@ -153,6 +153,35 @@
               "autoscaling:DeleteTags"
           ],
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroups",
+          "Effect": "Allow",
+          "Action": [
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:DeleteNodegroup"
+          ],
+          "Resource": [
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
+          ]
+      },
+      {
+          "Sid": "CAPAManagedNodegroupsAutoScalingRead",
+          "Effect": "Allow",
+          "Action": [
+              "autoscaling:DescribeAutoScalingGroups"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
+          "Effect": "Allow",
+          "Action": [
+              "iam:CreateServiceLinkedRole"
+          ],
+          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/en/modules/ROOT/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/en/modules/ROOT/assets/attachments/stratio-eks-policy.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
       {
+          "Sid": "EC2ReadOnly",
           "Effect": "Allow",
           "Action": [
               "ec2:CreateTags",
@@ -34,6 +35,9 @@
               "ecr:GetAuthorizationToken",
               "eks:CreateCluster",
               "eks:DescribeAddon",
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:UpdateNodegroupConfig",
               "eks:DescribeAddonVersions",
               "eks:UpdateAddon",
               "iam:ListOpenIDConnectProviders"
@@ -41,6 +45,7 @@
           "Resource": "*"
       },
       {
+          "Sid": "EC2WriteResources",
           "Effect": "Allow",
           "Action": [
               "ec2:AllocateAddress",
@@ -65,8 +70,10 @@
               "eks:DescribeCluster",
               "eks:CreateAddon",
               "eks:DeleteCluster",
+              "eks:DeleteNodegroup",
               "eks:ListAddons",
               "eks:TagResource",
+              "eks:UntagResource",
               "eks:UpdateClusterConfig",
               "eks:UpdateClusterVersion",
               "secretsmanager:CreateSecret",
@@ -84,10 +91,12 @@
               "arn:aws:ec2:*:${AWS_ACCOUNT_ID}:vpc/*",
               "arn:aws:ecr:*:*:repository/*",
               "arn:aws:eks:*:${AWS_ACCOUNT_ID}:addon/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*"
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
           ]
       },
       {
+          "Sid": "EC2SecurityGroups",
           "Effect": "Allow",
           "Action": [
               "ec2:AuthorizeSecurityGroupIngress"
@@ -97,6 +106,7 @@
           ]
       },
       {
+          "Sid": "SSMOptimizedAMI",
           "Effect": "Allow",
           "Action": [
               "ssm:GetParameter"
@@ -106,6 +116,7 @@
           ]
       },
       {
+          "Sid": "IAMAndOIDC",
           "Effect": "Allow",
           "Action": [
               "iam:CreateOpenIDConnectProvider",
@@ -113,13 +124,14 @@
               "iam:GetOpenIDConnectProvider",
               "iam:TagOpenIDConnectProvider",
               "iam:ListAttachedRolePolicies",
+              "iam:CreateServiceLinkedRole",
               "iam:CreateRole",
-              "iam:TagRole",
-              "iam:UntagRole"
+              "iam:TagRole"
           ],
           "Resource": [
               "arn:aws:iam::${AWS_ACCOUNT_ID}:role/*",
-              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*"
+              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*",
+              "arn:aws:iam::*:role/aws-service-role/*"
           ]
       },
       {
@@ -155,33 +167,12 @@
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
       },
       {
-          "Sid": "CAPAManagedNodegroups",
-          "Effect": "Allow",
-          "Action": [
-              "eks:CreateNodegroup",
-              "eks:DescribeNodegroup",
-              "eks:DeleteNodegroup"
-          ],
-          "Resource": [
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
-          ]
-      },
-      {
           "Sid": "CAPAManagedNodegroupsAutoScalingRead",
           "Effect": "Allow",
           "Action": [
               "autoscaling:DescribeAutoScalingGroups"
           ],
           "Resource": "*"
-      },
-      {
-          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
-          "Effect": "Allow",
-          "Action": [
-              "iam:CreateServiceLinkedRole"
-          ],
-          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/en/modules/ROOT/pages/what-is-new/release-notes.adoc
+++ b/stratio-docs/en/modules/ROOT/pages/what-is-new/release-notes.adoc
@@ -4,9 +4,9 @@ These are the highlights of the _Stratio Cloud Provisioner_ versions for the lat
 
 == 0.17.0-0.8.X
 
-* Soporte de _MachinePools_ en _clusters_ EKS con _control-plane_ gestionado. Los grupos de nodos sin _node++_++image_ se aprovisionan ahora como grupos de nodos gestionados por EKS (_AWSManagedMachinePool_) en lugar de instancias EC2 autogestionadas. Un _cluster_ puede combinar ambos tipos en el mismo descriptor.
-* Nuevo campo _ami++_++type_ en _worker++_++nodes_ para seleccionar el tipo de AMI del grupo de nodos gestionado. El valor por defecto es _BOTTLEROCKET_x86_64_.
-* Nuevo campo _mp++_++role++_++name_ en _control_plane.aws_ para asignar un rol IAM preexistente a todos los grupos de nodos gestionados, sin que _Stratio Cloud Provisioner_ cree uno nuevo.
+* Support for _MachinePools_ in EKS clusters with managed _control-plane_. Node groups without _node++_++image_ are now provisioned as EKS-managed node groups (_AWSManagedMachinePool_) instead of self-managed EC2 instances. A cluster can combine both types in the same descriptor.
+* New _ami++_++type_ field in _worker++_++nodes_ to select the AMI type of the managed node group. The default value is "BOTTLEROCKET++_++x86++_++64".
+* New _mp++_++role++_++name_ field in _control_plane.aws_ to assign a pre-existing IAM role to all managed node groups, without _Stratio Cloud Provisioner_ creating a new one.
 
 == 0.17.0-0.6 (Nov 15, 2024)
 

--- a/stratio-docs/en/modules/ROOT/pages/what-is-new/release-notes.adoc
+++ b/stratio-docs/en/modules/ROOT/pages/what-is-new/release-notes.adoc
@@ -2,6 +2,12 @@
 
 These are the highlights of the _Stratio Cloud Provisioner_ versions for the latest releases:
 
+== 0.17.0-0.8.X
+
+* Soporte de _MachinePools_ en _clusters_ EKS con _control-plane_ gestionado. Los grupos de nodos sin _node++_++image_ se aprovisionan ahora como grupos de nodos gestionados por EKS (_AWSManagedMachinePool_) en lugar de instancias EC2 autogestionadas. Un _cluster_ puede combinar ambos tipos en el mismo descriptor.
+* Nuevo campo _ami++_++type_ en _worker++_++nodes_ para seleccionar el tipo de AMI del grupo de nodos gestionado. El valor por defecto es _BOTTLEROCKET_x86_64_.
+* Nuevo campo _mp++_++role++_++name_ en _control_plane.aws_ para asignar un rol IAM preexistente a todos los grupos de nodos gestionados, sin que _Stratio Cloud Provisioner_ cree uno nuevo.
+
 == 0.17.0-0.6 (Nov 15, 2024)
 
 * CoreDNS replicas are now distributed across different nodes to improve availability.

--- a/stratio-docs/en/modules/operations-manual/assets/attachments/stratio-aws-temp-policy.json
+++ b/stratio-docs/en/modules/operations-manual/assets/attachments/stratio-aws-temp-policy.json
@@ -12,6 +12,7 @@
                 "iam:CreateInstanceProfile",
                 "iam:CreatePolicy",
                 "iam:CreatePolicyVersion",
+                "iam:DeletePolicyVersion",
                 "iam:CreateRole",
                 "iam:CreateUser",
                 "iam:DeleteGroup",

--- a/stratio-docs/en/modules/operations-manual/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/en/modules/operations-manual/assets/attachments/stratio-eks-policy.json
@@ -153,6 +153,35 @@
               "autoscaling:DeleteTags"
           ],
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroups",
+          "Effect": "Allow",
+          "Action": [
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:DeleteNodegroup"
+          ],
+          "Resource": [
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
+          ]
+      },
+      {
+          "Sid": "CAPAManagedNodegroupsAutoScalingRead",
+          "Effect": "Allow",
+          "Action": [
+              "autoscaling:DescribeAutoScalingGroups"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
+          "Effect": "Allow",
+          "Action": [
+              "iam:CreateServiceLinkedRole"
+          ],
+          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/en/modules/operations-manual/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/en/modules/operations-manual/assets/attachments/stratio-eks-policy.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
       {
+          "Sid": "EC2ReadOnly",
           "Effect": "Allow",
           "Action": [
               "ec2:CreateTags",
@@ -34,6 +35,9 @@
               "ecr:GetAuthorizationToken",
               "eks:CreateCluster",
               "eks:DescribeAddon",
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:UpdateNodegroupConfig",
               "eks:DescribeAddonVersions",
               "eks:UpdateAddon",
               "iam:ListOpenIDConnectProviders"
@@ -41,6 +45,7 @@
           "Resource": "*"
       },
       {
+          "Sid": "EC2WriteResources",
           "Effect": "Allow",
           "Action": [
               "ec2:AllocateAddress",
@@ -65,8 +70,10 @@
               "eks:DescribeCluster",
               "eks:CreateAddon",
               "eks:DeleteCluster",
+              "eks:DeleteNodegroup",
               "eks:ListAddons",
               "eks:TagResource",
+              "eks:UntagResource",
               "eks:UpdateClusterConfig",
               "eks:UpdateClusterVersion",
               "secretsmanager:CreateSecret",
@@ -84,10 +91,12 @@
               "arn:aws:ec2:*:${AWS_ACCOUNT_ID}:vpc/*",
               "arn:aws:ecr:*:*:repository/*",
               "arn:aws:eks:*:${AWS_ACCOUNT_ID}:addon/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*"
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
           ]
       },
       {
+          "Sid": "EC2SecurityGroups",
           "Effect": "Allow",
           "Action": [
               "ec2:AuthorizeSecurityGroupIngress"
@@ -97,6 +106,7 @@
           ]
       },
       {
+          "Sid": "SSMOptimizedAMI",
           "Effect": "Allow",
           "Action": [
               "ssm:GetParameter"
@@ -106,6 +116,7 @@
           ]
       },
       {
+          "Sid": "IAMAndOIDC",
           "Effect": "Allow",
           "Action": [
               "iam:CreateOpenIDConnectProvider",
@@ -113,13 +124,14 @@
               "iam:GetOpenIDConnectProvider",
               "iam:TagOpenIDConnectProvider",
               "iam:ListAttachedRolePolicies",
+              "iam:CreateServiceLinkedRole",
               "iam:CreateRole",
-              "iam:TagRole",
-              "iam:UntagRole"
+              "iam:TagRole"
           ],
           "Resource": [
               "arn:aws:iam::${AWS_ACCOUNT_ID}:role/*",
-              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*"
+              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*",
+              "arn:aws:iam::*:role/aws-service-role/*"
           ]
       },
       {
@@ -155,33 +167,12 @@
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
       },
       {
-          "Sid": "CAPAManagedNodegroups",
-          "Effect": "Allow",
-          "Action": [
-              "eks:CreateNodegroup",
-              "eks:DescribeNodegroup",
-              "eks:DeleteNodegroup"
-          ],
-          "Resource": [
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
-          ]
-      },
-      {
           "Sid": "CAPAManagedNodegroupsAutoScalingRead",
           "Effect": "Allow",
           "Action": [
               "autoscaling:DescribeAutoScalingGroups"
           ],
           "Resource": "*"
-      },
-      {
-          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
-          "Effect": "Allow",
-          "Action": [
-              "iam:CreateServiceLinkedRole"
-          ],
-          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -533,13 +533,14 @@ This section specifies _control-plane_ particulars.
 ^|Name ^|Description ^|Example ^|Optional
 
 |_aws_
-|Specific settings for EKS logging (API Server, audit, authenticator, controller++_++manager_, and/or _scheduler_).
+|Valores específicos de EKS. Incluye la configuración del _logging_ del _control-plane_ (_API Server, audit, authenticator, controller++_++manager_ y/o _scheduler_). Opcionalmente, incluye el nombre de un rol IAM preexistente para grupos de nodos gestionados (_mp++_++role++_++name_). Si se especifica, _Stratio Cloud Provisioner_ asigna ese rol a todos los grupos de nodos sin crear uno nuevo.
 a|
 
 [source,yaml]
 ----
 logging:
   api_server: true
+mp_role_name: "eks-nodegroup-role"
 ----
 
 |Yes
@@ -615,8 +616,18 @@ EKS must support the images used. See the https://docs.aws.amazon.com/es_es/eks/
 |Yes
 
 |_node++_++image_
-|Instance image for _worker_ nodes.
+|Imagen de instancia personalizada para los nodos _worker_. Si se especifica en un _cluster_ EKS gestionado, el grupo de nodos se crea como _MachineDeployment_ (nodo EC2 autogestionado). Mutuamente exclusivo con _ami++_++type_.
 |ami-0de933c15c9b49fb5
+|Yes
+
+|_ami++_++type_
+|Tipo de AMI para el grupo de nodos gestionado por EKS (_MachinePool_). Solo válido con _control-plane_ gestionado. Si no se especifica, se usa _BOTTLEROCKET_x86_64_ por defecto. Mutuamente exclusivo con _node++_++image_.
+|BOTTLEROCKET_x86_64
+|Yes
+
+|_spot_
+|Activa el uso de instancias _spot_ en el grupo de nodos. Permite reducir costes a cambio de mayor riesgo de interrupción.
+|true
 |Yes
 
 |_labels_
@@ -669,6 +680,8 @@ root_volume:
 
 NOTE: Setting _min++_++size_ to zero is supported, allowing the autoscaler to scale down to zero nodes, which can save costs, particularly for groups with zero deployed instances when not needed.
 
+NOTE: En _clusters_ EKS con _control-plane_ gestionado, el tipo de grupo de nodos depende del campo _node++_++image_. Si está presente, se crea un _MachineDeployment_ (EC2 autogestionado). Si no está presente, se crea un _MachinePool_ (grupo gestionado por EKS). Un _cluster_ puede combinar ambos tipos. Para escalar un _MachinePool_ a cero réplicas, _max++_++size_ debe ser mayor o igual al número de zonas de disponibilidad del _cluster_.
+
 === _Stratio KEOS_
 
 Installation parameters for _keos-installer_ are provided here.
@@ -702,8 +715,11 @@ This example includes:
 * Use of VPC and custom subnets (pre-created; optional).
 * Default _StorageClass_ defined (optional).
 * Enabled API Server logs in EKS.
+* Uso de grupos de nodos gestionados por EKS (_MachinePool_): los grupos sin _node++_++image_ se crean como _MachinePools_ con AMI gestionada por EKS.
+* Rol IAM preexistente para los grupos de nodos (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ lo asigna sin crear uno nuevo.
 * Worker node groups with multiple configurations:
 ** Different instance types.
+** With explicit _ami++_++type_ (_BOTTLEROCKET_x86_64_) and default AMI.
 ** With SSH key.
 ** Kubernetes labels.
 ** Autoscaling ranges.
@@ -764,6 +780,7 @@ spec:
     aws:
       logging:
         api_server: true
+      mp_role_name: "eks-nodegroup-role"
     managed: true
   worker_nodes:
     - name: eks-prod-xlarge
@@ -771,6 +788,7 @@ spec:
       max_size: 18
       min_size: 6
       size: m6i.xlarge
+      ami_type: BOTTLEROCKET_x86_64
       labels:
         disktype: standard
       root_volume:

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -13,7 +13,7 @@ For automated provisioning in EKS, actions must be performed across multiple ser
 +
 To deploy EKS, you must manually create the "AWSServiceRoleForAmazonEKS" role and attach the "AmazonEKSServiceRolePolicy" (which is created by default in AWS).
 +
-NOTE: Si el _cluster_ incluye grupos de tipo _MachinePool_ (nodegroups gestionados por EKS), el usuario de despliegue necesita permisos adicionales: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups` e `iam:CreateServiceLinkedRole`. Ya están incluidos en `stratio-eks-policy.json`.
+NOTE: If the cluster includes _MachinePool_-type groups (EKS-managed nodegroups), the deployment user needs additional permissions: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, and `iam:CreateServiceLinkedRole`. These permissions are already included in the _stratio-eks-policy.json_ file.
 
 * Certified operating systems
 +
@@ -41,7 +41,6 @@ In GKE, the service account used to provision clusters must have the following s
 In GKE, the default operating system is Container-Optimized OS (COS), and no specific image needs to be specified.
 
 * Enable the Google Kubernetes Engine API for GKE.
-
 * Bastion.
 +
 To deploy _Stratio KEOS_ on GKE, you need a bastion to facilitate communication with the cluster. Create it on the same network as the cluster.
@@ -535,7 +534,7 @@ This section specifies _control-plane_ particulars.
 ^|Name ^|Description ^|Example ^|Optional
 
 |_aws_
-|Valores específicos de EKS. Incluye la configuración del _logging_ del _control-plane_ (_API Server, audit, authenticator, controller++_++manager_ y/o _scheduler_). Opcionalmente, incluye el nombre de un rol IAM preexistente para grupos de nodos gestionados (_mp++_++role++_++name_). Si se especifica, _Stratio Cloud Provisioner_ asigna ese rol a todos los grupos de nodos sin crear uno nuevo.
+|EKS-specific values. Includes the _control-plane_ logging configuration ("api", "audit", "authenticator", "controllerManager", or "scheduler"). Optionally, it includes the name of a pre-existing IAM role for the managed node groups (_mp++_++role++_++name_). If specified, _Stratio Cloud Provisioner_ assigns that role to all node groups without creating a new one.
 a|
 
 [source,yaml]
@@ -555,7 +554,6 @@ a|
 ----
 cluster_network:
   private_cluster:
-
 
 master_authorized_networks_config:
 
@@ -618,17 +616,17 @@ EKS must support the images used. See the https://docs.aws.amazon.com/es_es/eks/
 |Yes
 
 |_node++_++image_
-|Imagen de instancia personalizada para los nodos _worker_. Si se especifica en un _cluster_ EKS gestionado, el grupo de nodos se crea como _MachineDeployment_ (nodo EC2 autogestionado). Mutuamente exclusivo con _ami++_++type_.
+|Custom instance image for the _worker_ nodes. If specified in a managed EKS cluster, the node group is created as a _MachineDeployment_ (self-managed EC2 node). It is mutually exclusive with _ami++_++type_.
 |ami-0de933c15c9b49fb5
 |Yes
 
 |_ami++_++type_
-|Tipo de AMI para el grupo de nodos gestionado por EKS (_MachinePool_). Solo válido con _control-plane_ gestionado. Si no se especifica, se usa _BOTTLEROCKET_x86_64_ por defecto. Mutuamente exclusivo con _node++_++image_.
+|AMI type for the EKS-managed node group (_MachinePool_). Only valid with managed _control-plane_. If not specified, "BOTTLEROCKET++_++x86++_++64" is used by default. It is mutually exclusive with _node++_++image_.
 |BOTTLEROCKET_x86_64
 |Yes
 
 |_spot_
-|Activa el uso de instancias _spot_ en el grupo de nodos. Permite reducir costes a cambio de mayor riesgo de interrupción.
+|Enables the use of _spot_ instances in the node group. It reduces costs at the expense of a higher risk of interruption.
 |true
 |Yes
 
@@ -682,7 +680,7 @@ root_volume:
 
 NOTE: Setting _min++_++size_ to zero is supported, allowing the autoscaler to scale down to zero nodes, which can save costs, particularly for groups with zero deployed instances when not needed.
 
-NOTE: En _clusters_ EKS con _control-plane_ gestionado, el tipo de grupo de nodos depende del campo _node++_++image_. Si está presente, se crea un _MachineDeployment_ (EC2 autogestionado). Si no está presente, se crea un _MachinePool_ (grupo gestionado por EKS). Un _cluster_ puede combinar ambos tipos. Para escalar un _MachinePool_ a cero réplicas, _max++_++size_ debe ser mayor o igual al número de zonas de disponibilidad del _cluster_.
+NOTE: On EKS clusters with managed _control-plane_, the node group type depends on the _node++_++image_ field. If present, a _MachineDeployment_ (self-managed EC2) is created. If not present, a _MachinePool_ (EKS-managed group) is created. A cluster can combine both types. To scale a _MachinePool_ to zero replicas, _max++_++size_ must be greater than or equal to the number of availability zones in the cluster.
 
 === _Stratio KEOS_
 
@@ -709,27 +707,27 @@ Two descriptor examples are provided demonstrating _Stratio Cloud Provisioner_ c
 
 ==== EKS
 
-This example includes:
+This example shows the following particularities:
 
-* AWS cluster with managed _control-plane_ (EKS).
-* Kubernetes 1.26.x (EKS ignores patch version).
-* Use of ECR as Docker registry (no credentials needed).
-* Use of VPC and custom subnets (pre-created; optional).
-* Default _StorageClass_ defined (optional).
-* Enabled API Server logs in EKS.
-* Use of EKS-managed node groups (_MachinePool_): groups without _node++_++image_ are created as _MachinePools_ with EKS-managed AMI.
-* Pre-existing IAM role for node groups (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ assigns it without creating a new one.
-* Mixed cluster with EKS-managed groups (_MachinePool_) and custom AMI groups (_MachineDeployment_): the group with _node++_++image_ is created as a _MachineDeployment_ (self-managed EC2).
-* Worker node groups with multiple configurations:
+* Cluster on AWS with managed _control-plane_ (EKS).
+* Kubernetes version 1.26.x (EKS does not take the _patch_ version into account).
+* Use of ECR as a _Docker registry_ (does not require credentials).
+* Use of custom VPC and subnets (created beforehand). This section is optional.
+* Definition of a default _StorageClass_. This section is optional.
+* _API Server_ logs are enabled on EKS.
+* Use of EKS-managed node groups (_MachinePool_): groups without _node++_++image_ are created as _MachinePools_ with an EKS-managed AMI.
+* Pre-existing IAM role for the node groups (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ assigns it without creating a new one.
+* Coexistence of managed groups (_MachinePool_) and groups with a custom AMI (_MachineDeployment_): the group with _node++_++image_ is created as a _MachineDeployment_ (self-managed EC2).
+* _Worker_ node groups with various use cases:
 ** Different instance types.
-** With explicit _ami++_++type_ (_BOTTLEROCKET_x86_64_) and default AMI.
+** With explicit _ami++_++type_ ("BOTTLEROCKET++_++x86++_++64") and with default AMI.
 ** With SSH key.
-** Kubernetes labels.
-** Autoscaling ranges.
-** Fixed AZ.
-** Custom root volume.
-** Spot instances.
-** AZ distribution: balanced or unbalanced.
+** With Kubernetes labels.
+** With autoscaling ranges.
+** In a fixed zone.
+** With disk customizations.
+** With _spot_ instances.
+** AZ distribution cases: balanced and unbalanced.
 
 [source,yaml]
 ----
@@ -828,15 +826,16 @@ spec:
 
 This example includes:
 
-* GCP cluster with managed _control-plane_.
-* Kubernetes 1.28.x.
-* Use of Docker registry of type GAR.
-* Use of Helm repository of type GAR.
-* _nodes++_++identity_ (default node service account configurable only at creation time).
-* Scopes (list of access scopes for service account).
+* Cluster on GCP with managed _control-plane_.
+* Kubernetes version 1.28.x.
+* Use of a _gar_-type _Docker registry_.
+* Use of a _gar_-type Helm repository.
+* _enable++_++secure++_++boot_ (enabled by default).
+* _nodes++_++identity_ (default service account for the nodes). (Only configurable at cluster creation time).
+* _scopes_ (list of scopes that will be available for this service account).
 * No DNS zone control (enabled by default).
-* Default _StorageClass_ definition (optional).
-* _Control-plane_ settings configurable only at creation time:
+* Definition of a default _StorageClass_. This section is optional.
+* _control-plane_ features: only configurable at cluster creation time.
 ** _cluster++_++network_
 *** _private++_++cluster_
 **** _enable++_++private++_++endpoint_
@@ -855,13 +854,13 @@ This example includes:
 ** _logging++_++config_
 *** _system++_++components_
 *** _workloads_
-* _Worker_ node groups with multiple configurations:
+* _Worker_ node groups with multiple use cases:
 ** Different instance types.
-** No specific image (uses cloud provider default).
-** Kubernetes labels.
-** Autoscaling ranges.
-** Fixed AZ.
-** Custom root volume.
+** Without a specific image (the default cloud provider image will be used).
+** With K8s labels.
+** With autoscaling ranges.
+** In a fixed zone.
+** With disk customizations.
 
 [source,yaml]
 ----

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -772,7 +772,7 @@ spec:
   deploy_autoscaler: false
   keos:
     flavour: production
-    version: 1.31.0
+    version: 1.3.x
   security:
     aws:
       create_iam: false
@@ -897,7 +897,7 @@ spec:
       labels: "owner=stratio"
   keos:
     flavour: production
-    version: 1.31.0
+    version: 1.3.x
   control_plane:
     managed: true
     gcp:
@@ -954,8 +954,8 @@ metadata:
 spec:
     private_registry: true
     private_helm_repo: true
-    cluster_operator_version: 0.3.4
-    cluster_operator_image_version: 0.3.4
+    cluster_operator_version: 0.8.x
+    cluster_operator_image_version: 0.8.x
 ----
 
 ==== Unmanaged Azure
@@ -1013,7 +1013,7 @@ spec:
     manage_zone: false
   keos:
     flavour: production
-    version: 1.31.0
+    version: 1.3.x
   security:
     control_plane_identity: "/subscriptions/6e2a38cd-../stratio-control-plane"
     nodes_identity: "/subscriptions/6e2a38cd-../stratio-nodes"

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -12,6 +12,8 @@ For automated provisioning in EKS, actions must be performed across multiple ser
 ** xref:attachment$stratio-aws-temp-policy.json[Download temporary permissions for EKS].
 +
 To deploy EKS, you must manually create the "AWSServiceRoleForAmazonEKS" role and attach the "AmazonEKSServiceRolePolicy" (which is created by default in AWS).
++
+NOTE: Si el _cluster_ incluye grupos de tipo _MachinePool_ (nodegroups gestionados por EKS), el usuario de despliegue necesita permisos adicionales: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups` e `iam:CreateServiceLinkedRole`. Ya están incluidos en `stratio-eks-policy.json`.
 
 * Certified operating systems
 +

--- a/stratio-docs/en/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/installation.adoc
@@ -715,8 +715,9 @@ This example includes:
 * Use of VPC and custom subnets (pre-created; optional).
 * Default _StorageClass_ defined (optional).
 * Enabled API Server logs in EKS.
-* Uso de grupos de nodos gestionados por EKS (_MachinePool_): los grupos sin _node++_++image_ se crean como _MachinePools_ con AMI gestionada por EKS.
-* Rol IAM preexistente para los grupos de nodos (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ lo asigna sin crear uno nuevo.
+* Use of EKS-managed node groups (_MachinePool_): groups without _node++_++image_ are created as _MachinePools_ with EKS-managed AMI.
+* Pre-existing IAM role for node groups (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ assigns it without creating a new one.
+* Mixed cluster with EKS-managed groups (_MachinePool_) and custom AMI groups (_MachineDeployment_): the group with _node++_++image_ is created as a _MachineDeployment_ (self-managed EC2).
 * Worker node groups with multiple configurations:
 ** Different instance types.
 ** With explicit _ami++_++type_ (_BOTTLEROCKET_x86_64_) and default AMI.
@@ -798,6 +799,8 @@ spec:
       ssh_key: stg-key
     - name: eks-prod-medium-spot
       quantity: 4
+      min_size: 4
+      max_size: 8
       zone_distribution: unbalanced
       size: t3.medium
       spot: true
@@ -805,8 +808,18 @@ spec:
         disktype: standard
     - name: eks-prod-medium-az
       quantity: 3
+      min_size: 3
+      max_size: 6
       size: t3.medium
       az: eu-west-1c
+    - name: eks-prod-custom-ami
+      quantity: 2
+      max_size: 6
+      min_size: 2
+      size: m6i.large
+      node_image: "ami-0a1234567890abcde"
+      labels:
+        workload: custom
 ----
 
 ==== GKE

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -436,7 +436,7 @@ NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` pa
 
 . Espera a que los nodos MP estén en estado `Ready`.
 
-. Verifica la capacidad y obtén los comandos de drenado:
+. Verifica la capacidad y obtén las instrucciones de drenado y eliminación:
 +
 [source,bash]
 ----
@@ -444,10 +444,10 @@ python3 migrate-workers-to-machinepool.py \
   --check-ready <nombre>-mp
 ----
 +
-El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
+El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente, y las instrucciones para eliminar la entrada del grupo MD del objeto `KeosCluster`. Revisa las instrucciones antes de ejecutarlas.
 
 . Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
 
-. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
+. Sigue las instrucciones que imprime el _script_ para eliminar el grupo MD del objeto `KeosCluster`.
 
 NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -400,6 +400,7 @@ La migración es un proceso asistido y por fases. El _script_ `migrate-workers-t
 
 * cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
 * `KeosCluster.status.ready = true`.
+* La política EKS del usuario de despliegue debe incluir los permisos de gestión de nodegroups de `stratio-eks-policy.json` (`eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, `iam:CreateServiceLinkedRole`).
 
 Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
 

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -201,16 +201,6 @@ WARNING: The `--private` flag is only required if you want to *force the use of 
 
 NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
 
-==== _MachineDeployments_ (con _node++_++image_)
-
-La imagen de nodo es fija. Al cambiar _k8s++_++version_ en el descriptor, solo se actualiza el _control-plane_. Para actualizar los nodos de tipo _MachineDeployment_:
-
-. Obtén el identificador de la AMI para la nueva versión de Kubernetes en la región del _cluster_.
-. Actualiza el campo _node++_++image_ de cada grupo afectado en el descriptor.
-. Aplica el descriptor actualizado con Stratio Cloud Provisioner.
-
-NOTE: Si no actualizas _node++_++image_, los nodos de tipo _MachineDeployment_ mantienen la versión de _kubelet_ de la AMI anterior. El _control-plane_ puede estar en una versión superior a la de esos nodos.
-
 ==== Migración de _MachineDeployments_ a _MachinePools_
 
 WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -243,7 +243,7 @@ kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
   -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
 +
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator interpreta un `apply` como la primera reconciliación del _cluster_ y actualiza la anotación de estado sin ejecutar los cambios reales sobre la infraestructura.
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
 
 . Espera a que los nodos MP estén en estado `Ready`.
 

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -197,72 +197,6 @@ This means that:
 
 WARNING: The `--private` flag is only required if you want to *force the use of private repositories* and the current `ClusterConfig` does not already have it enabled.
 
-=== _Clusters_ EKS con _MachinePools_
-
-NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
-
-==== Migración de _MachineDeployments_ a _MachinePools_
-
-WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
-
-La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
-
-===== Prerequisitos
-
-* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
-* `KeosCluster.status.ready = true`.
-
-Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
-
-===== Fase 1 — Preparación del _cluster_
-
-IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
-
-Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
-
-[source,bash]
-----
-python3 migrate-workers-to-machinepool.py \
-  --kubeconfig ~/.kube/config
-----
-
-El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
-
-El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
-
-===== Fase 2 — Migración de grupos de nodos
-
-Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
-
-. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
-+
-[source,bash]
-----
-kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
-  --type=json \
-  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
-----
-+
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
-
-. Espera a que los nodos MP estén en estado `Ready`.
-
-. Verifica la capacidad y obtén los comandos de drenado:
-+
-[source,bash]
-----
-python3 migrate-workers-to-machinepool.py \
-  --check-ready <nombre>-mp
-----
-+
-El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
-
-. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
-
-. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
-
-NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
-
 == Using the upgrade script
 
 === Syntax
@@ -451,3 +385,69 @@ kubectl get machinepools -A
 kubectl get nodes
 # Verify that CAPX logs do not contain errors after the upgrade
 ----
+
+== _Clusters_ EKS con _MachinePools_
+
+NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
+
+=== Migración de _MachineDeployments_ a _MachinePools_
+
+WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
+
+La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
+
+==== Prerequisitos
+
+* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
+* `KeosCluster.status.ready = true`.
+
+Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
+
+==== Fase 1 — Preparación del _cluster_
+
+IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
+
+Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
+
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --kubeconfig ~/.kube/config
+----
+
+El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
+
+El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
+
+==== Fase 2 — Migración de grupos de nodos
+
+Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
+
+. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
++
+[source,bash]
+----
+kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
+----
++
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
+
+. Espera a que los nodos MP estén en estado `Ready`.
+
+. Verifica la capacidad y obtén los comandos de drenado:
++
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --check-ready <nombre>-mp
+----
++
+El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
+
+. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
+
+. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
+
+NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -243,7 +243,7 @@ kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
   -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
 +
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`.
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator interpreta un `apply` como la primera reconciliación del _cluster_ y actualiza la anotación de estado sin ejecutar los cambios reales sobre la infraestructura.
 
 . Espera a que los nodos MP estén en estado `Ready`.
 

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -408,7 +408,6 @@ If the cluster has earlier versions, run `upgrade-provisioner.py` first.
 
 IMPORTANT: Before running the script, verify that the image and the chart of _cluster-operator_ for this version are available in the container registry and in the Helm repository configured for the cluster. If the cluster uses private registries (`private_registry=true` or `private_helm_repo=true`), make sure the artifacts have been published before continuing.
 
-
 Run the preparation script inside the _Stratio Cloud Provisioner_ container:
 
 [source,bash]

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -197,6 +197,84 @@ This means that:
 
 WARNING: The `--private` flag is only required if you want to *force the use of private repositories* and the current `ClusterConfig` does not already have it enabled.
 
+=== _Clusters_ EKS con _MachinePools_
+
+NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
+
+==== _MachineDeployments_ (con _node++_++image_)
+
+La imagen de nodo es fija. Al cambiar _k8s++_++version_ en el descriptor, solo se actualiza el _control-plane_. Para actualizar los nodos de tipo _MachineDeployment_:
+
+. Obtén el identificador de la AMI para la nueva versión de Kubernetes en la región del _cluster_.
+. Actualiza el campo _node++_++image_ de cada grupo afectado en el descriptor.
+. Aplica el descriptor actualizado con Stratio Cloud Provisioner.
+
+NOTE: Si no actualizas _node++_++image_, los nodos de tipo _MachineDeployment_ mantienen la versión de _kubelet_ de la AMI anterior. El _control-plane_ puede estar en una versión superior a la de esos nodos.
+
+==== Migración de _MachineDeployments_ a _MachinePools_
+
+WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
+
+La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
+
+===== Prerequisitos
+
+* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
+* `KeosCluster.status.ready = true`.
+
+Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
+
+===== Fase 1 — Preparación del _cluster_
+
+IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
+
+Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
+
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --kubeconfig ~/.kube/config
+----
+
+El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
+
+El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
+
+===== Fase 2 — Migración de grupos de nodos
+
+Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
+
+. Añade el nuevo grupo MP al descriptor. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
++
+[source,yaml]
+----
+worker_nodes:
+  - name: <nombre>-mp
+    size: <mismo-size>
+    quantity: <misma-cantidad>
+    az: <misma-az>
+    ami_type: BOTTLEROCKET_x86_64   # opcional
+    labels: {}                       # mismas labels que el grupo MD
+----
+
+. Aplica el descriptor con Stratio Cloud Provisioner y espera a que los nodos MP estén en estado `Ready`.
+
+. Verifica la capacidad y obtén los comandos de drenado:
++
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --check-ready <nombre>-mp
+----
++
+El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
+
+. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
+
+. Elimina el grupo MD del descriptor y aplícalo con Stratio Cloud Provisioner.
+
+NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
+
 == Using the upgrade script
 
 === Syntax

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -403,6 +403,21 @@ La migración es un proceso asistido y por fases. El _script_ `migrate-workers-t
 
 Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
 
+==== Levantar el contenedor
+
+El _script_ de migración se ejecuta dentro del mismo contenedor que el _upgrade_. Desde el directorio de trabajo que contiene `secrets.yml` y `.kube/config`:
+
+[source,bash]
+----
+docker run \
+  --name cloud-provisioner-upgrade-0.8.X \
+  --net host \
+  -it \
+  -v $PWD/secrets.yml:/upgrade/secrets.yml \
+  -v $PWD/.kube/config:/upgrade/.kube/config \
+  cloud-provisioner-upgrade:0.17.0-0.8.X
+----
+
 ==== Fase 1 — Preparación del _cluster_
 
 IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -244,20 +244,18 @@ El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`Machi
 
 Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
 
-. Añade el nuevo grupo MP al descriptor. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
+. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
 +
-[source,yaml]
+[source,bash]
 ----
-worker_nodes:
-  - name: <nombre>-mp
-    size: <mismo-size>
-    quantity: <misma-cantidad>
-    az: <misma-az>
-    ami_type: BOTTLEROCKET_x86_64   # opcional
-    labels: {}                       # mismas labels que el grupo MD
+kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
++
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`.
 
-. Aplica el descriptor con Stratio Cloud Provisioner y espera a que los nodos MP estén en estado `Ready`.
+. Espera a que los nodos MP estén en estado `Ready`.
 
 . Verifica la capacidad y obtén los comandos de drenado:
 +
@@ -271,7 +269,7 @@ El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivale
 
 . Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
 
-. Elimina el grupo MD del descriptor y aplícalo con Stratio Cloud Provisioner.
+. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
 
 NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
 

--- a/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/en/modules/operations-manual/pages/upgrade.adoc
@@ -386,44 +386,30 @@ kubectl get nodes
 # Verify that CAPX logs do not contain errors after the upgrade
 ----
 
-== _Clusters_ EKS con _MachinePools_
+== EKS clusters with _MachinePools_
 
-NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
+NOTE: _MachinePools_ are only available on clusters created with this version of _Stratio Cloud Provisioner_. There is no automatic migration from _MachineDeployments_ to _MachinePools_ on existing clusters. To migrate an existing cluster, see the <<_migration_from_machinepools_to_MachinePools_, migration from _MachineDeployments_ to _MachinePools_>>.
 
-=== Migración de _MachineDeployments_ a _MachinePools_
+=== Migration from _MachineDeployments_ to _MachinePools_
 
-WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
+WARNING: This procedure applies only to EKS clusters (AWS managed). It is not available for Azure VMs or for GKE.
 
-La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
+The migration is an assisted, phased process. The `migrate-workers-to-machinepool.py` script prepares the cluster and validates capacity before each drain. Nodes are migrated manually, one by one, at your chosen pace.
 
-==== Prerequisitos
+==== Prerequisites
 
-* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
+* cluster-operator >= 0.6.1 and CAPA >= v2.9.2 on the cluster.
 * `KeosCluster.status.ready = true`.
-* La política EKS del usuario de despliegue debe incluir los permisos de gestión de nodegroups de `stratio-eks-policy.json` (`eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, `iam:CreateServiceLinkedRole`).
+* The EKS policy of the deployment user must include the nodegroup management permissions from the _stratio-eks-policy.json_ file: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, and `iam:CreateServiceLinkedRole`.
 
-Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
+If the cluster has earlier versions, run `upgrade-provisioner.py` first.
 
-==== Levantar el contenedor
+==== Phase 1: cluster preparation
 
-El _script_ de migración se ejecuta dentro del mismo contenedor que el _upgrade_. Desde el directorio de trabajo que contiene `secrets.yml` y `.kube/config`:
+IMPORTANT: Before running the script, verify that the image and the chart of _cluster-operator_ for this version are available in the container registry and in the Helm repository configured for the cluster. If the cluster uses private registries (`private_registry=true` or `private_helm_repo=true`), make sure the artifacts have been published before continuing.
 
-[source,bash]
-----
-docker run \
-  --name cloud-provisioner-upgrade-0.8.X \
-  --net host \
-  -it \
-  -v $PWD/secrets.yml:/upgrade/secrets.yml \
-  -v $PWD/.kube/config:/upgrade/.kube/config \
-  cloud-provisioner-upgrade:0.17.0-0.8.X
-----
 
-==== Fase 1 — Preparación del _cluster_
-
-IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
-
-Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
+Run the preparation script inside the _Stratio Cloud Provisioner_ container:
 
 [source,bash]
 ----
@@ -431,39 +417,37 @@ python3 migrate-workers-to-machinepool.py \
   --kubeconfig ~/.kube/config
 ----
 
-El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
+By default, the script uses the _cluster-operator_ version included in this version of _Stratio Cloud Provisioner_. You can override it with `--cluster-operator-version <version>` if needed.
 
-El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
+The script validates the prerequisites, activates the CAPA _feature gates_ (`MachinePool=true` and `EKSAllowAddRoles=true`), and upgrades _cluster-operator_ to the indicated version.
 
-==== Fase 2 — Migración de grupos de nodos
+==== Phase 2: node group migration
 
-Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
+Repeat the following steps for each node group you want to migrate:
 
-. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
+. Add the new _MachinePool_ group to the `KeosCluster` object. Omit `node_image` and specify `ami_type` optionally (default is "BOTTLEROCKET_x86_64"):
 +
 [source,bash]
 ----
-kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
+kubectl patch keoscluster <cluster-name> -n cluster-<cluster-name> \
   --type=json \
-  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
+  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<name>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
 +
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
+NOTE: Use `--type=json` with the `add` operation and the `/spec/worker_nodes/-` path to add the group without replacing the existing ones. Never use `kubectl apply` on the `KeosCluster`: _cluster-operator_ detects the `kubectl.kubernetes.io/last-applied-configuration` annotation that `apply` generates and skips the actual reconciliation cycle, so changes to `spec.worker_nodes` are never processed.
 
-. Espera a que los nodos MP estén en estado `Ready`.
-
-. Verifica la capacidad y obtén las instrucciones de drenado y eliminación:
+. Wait until the _MachinePool_ nodes are in _Ready_ state.
+. Verify the capacity and get the drain and deletion instructions:
 +
 [source,bash]
 ----
 python3 migrate-workers-to-machinepool.py \
-  --check-ready <nombre>-mp
+  --check-ready <name>-mp
 ----
 +
-El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente, y las instrucciones para eliminar la entrada del grupo MD del objeto `KeosCluster`. Revisa las instrucciones antes de ejecutarlas.
+The script prints the drain commands for each node of the equivalent _MachineDeployment_ group, as well as the instructions to remove that group's entry from the `KeosCluster` object. Review the instructions before running them.
 
-. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
+. Run the drain commands the script prints, one by one. Check the cluster status between each node.
+. Follow the instructions the script prints to remove the _MachineDeployment_ group from the `KeosCluster` object.
 
-. Sigue las instrucciones que imprime el _script_ para eliminar el grupo MD del objeto `KeosCluster`.
-
-NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
+NOTE: Do not remove the _MachineDeployment_ group until all its nodes have been drained and the _MachinePool_ group has enough capacity to absorb the workload.

--- a/stratio-docs/es/modules/ROOT/assets/attachments/stratio-aws-temp-policy.json
+++ b/stratio-docs/es/modules/ROOT/assets/attachments/stratio-aws-temp-policy.json
@@ -12,6 +12,7 @@
                 "iam:CreateInstanceProfile",
                 "iam:CreatePolicy",
                 "iam:CreatePolicyVersion",
+                "iam:DeletePolicyVersion",
                 "iam:CreateRole",
                 "iam:CreateUser",
                 "iam:DeleteGroup",

--- a/stratio-docs/es/modules/ROOT/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/es/modules/ROOT/assets/attachments/stratio-eks-policy.json
@@ -153,6 +153,35 @@
               "autoscaling:DeleteTags"
           ],
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroups",
+          "Effect": "Allow",
+          "Action": [
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:DeleteNodegroup"
+          ],
+          "Resource": [
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
+          ]
+      },
+      {
+          "Sid": "CAPAManagedNodegroupsAutoScalingRead",
+          "Effect": "Allow",
+          "Action": [
+              "autoscaling:DescribeAutoScalingGroups"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
+          "Effect": "Allow",
+          "Action": [
+              "iam:CreateServiceLinkedRole"
+          ],
+          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/es/modules/ROOT/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/es/modules/ROOT/assets/attachments/stratio-eks-policy.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
       {
+          "Sid": "EC2ReadOnly",
           "Effect": "Allow",
           "Action": [
               "ec2:CreateTags",
@@ -34,6 +35,9 @@
               "ecr:GetAuthorizationToken",
               "eks:CreateCluster",
               "eks:DescribeAddon",
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:UpdateNodegroupConfig",
               "eks:DescribeAddonVersions",
               "eks:UpdateAddon",
               "iam:ListOpenIDConnectProviders"
@@ -41,6 +45,7 @@
           "Resource": "*"
       },
       {
+          "Sid": "EC2WriteResources",
           "Effect": "Allow",
           "Action": [
               "ec2:AllocateAddress",
@@ -65,8 +70,10 @@
               "eks:DescribeCluster",
               "eks:CreateAddon",
               "eks:DeleteCluster",
+              "eks:DeleteNodegroup",
               "eks:ListAddons",
               "eks:TagResource",
+              "eks:UntagResource",
               "eks:UpdateClusterConfig",
               "eks:UpdateClusterVersion",
               "secretsmanager:CreateSecret",
@@ -84,10 +91,12 @@
               "arn:aws:ec2:*:${AWS_ACCOUNT_ID}:vpc/*",
               "arn:aws:ecr:*:*:repository/*",
               "arn:aws:eks:*:${AWS_ACCOUNT_ID}:addon/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*"
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
           ]
       },
       {
+          "Sid": "EC2SecurityGroups",
           "Effect": "Allow",
           "Action": [
               "ec2:AuthorizeSecurityGroupIngress"
@@ -97,6 +106,7 @@
           ]
       },
       {
+          "Sid": "SSMOptimizedAMI",
           "Effect": "Allow",
           "Action": [
               "ssm:GetParameter"
@@ -106,6 +116,7 @@
           ]
       },
       {
+          "Sid": "IAMAndOIDC",
           "Effect": "Allow",
           "Action": [
               "iam:CreateOpenIDConnectProvider",
@@ -113,13 +124,14 @@
               "iam:GetOpenIDConnectProvider",
               "iam:TagOpenIDConnectProvider",
               "iam:ListAttachedRolePolicies",
+              "iam:CreateServiceLinkedRole",
               "iam:CreateRole",
-              "iam:TagRole",
-              "iam:UntagRole"
+              "iam:TagRole"
           ],
           "Resource": [
               "arn:aws:iam::${AWS_ACCOUNT_ID}:role/*",
-              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*"
+              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*",
+              "arn:aws:iam::*:role/aws-service-role/*"
           ]
       },
       {
@@ -155,33 +167,12 @@
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
       },
       {
-          "Sid": "CAPAManagedNodegroups",
-          "Effect": "Allow",
-          "Action": [
-              "eks:CreateNodegroup",
-              "eks:DescribeNodegroup",
-              "eks:DeleteNodegroup"
-          ],
-          "Resource": [
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
-          ]
-      },
-      {
           "Sid": "CAPAManagedNodegroupsAutoScalingRead",
           "Effect": "Allow",
           "Action": [
               "autoscaling:DescribeAutoScalingGroups"
           ],
           "Resource": "*"
-      },
-      {
-          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
-          "Effect": "Allow",
-          "Action": [
-              "iam:CreateServiceLinkedRole"
-          ],
-          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/es/modules/ROOT/pages/what-is-new/release-notes.adoc
+++ b/stratio-docs/es/modules/ROOT/pages/what-is-new/release-notes.adoc
@@ -4,8 +4,8 @@ Estos son los aspectos más destacados de las versiones de _Stratio Cloud Provis
 
 == 0.17.0-0.8.X
 
-* Soporte de _MachinePools_ en _clusters_ EKS con _control-plane_ gestionado. Los grupos de nodos sin _node++_++image_ se aprovisionan ahora como grupos de nodos gestionados por EKS (_AWSManagedMachinePool_) en lugar de instancias EC2 autogestionadas. Un _cluster_ puede combinar ambos tipos en el mismo descriptor.
-* Nuevo campo _ami++_++type_ en _worker++_++nodes_ para seleccionar el tipo de AMI del grupo de nodos gestionado. El valor por defecto es _BOTTLEROCKET_x86_64_.
+* Soporte de _MachinePools_ en _clusters_ EKS con _control-plane_ gestionado. Los grupos de nodos sin _node++_++image_ se aprovisionan ahora como grupos de nodos gestionados por EKS (_AWSManagedMachinePool_) en lugar de instancias EC2 autogestionadas. Un _cluster_ puede combinar ambos tipos en un mismo descriptor.
+* Nuevo campo _ami++_++type_ en _worker++_++nodes_ para seleccionar el tipo de AMI del grupo de nodos gestionado. El valor por defecto es "BOTTLEROCKET++_++x86++_++64".
 * Nuevo campo _mp++_++role++_++name_ en _control_plane.aws_ para asignar un rol IAM preexistente a todos los grupos de nodos gestionados, sin que _Stratio Cloud Provisioner_ cree uno nuevo.
 
 == 0.17.0-0.6 (15 de noviembre de 2024)

--- a/stratio-docs/es/modules/ROOT/pages/what-is-new/release-notes.adoc
+++ b/stratio-docs/es/modules/ROOT/pages/what-is-new/release-notes.adoc
@@ -2,6 +2,12 @@
 
 Estos son los aspectos más destacados de las versiones de _Stratio Cloud Provisioner_ para los últimos lanzamientos:
 
+== 0.17.0-0.8.X
+
+* Soporte de _MachinePools_ en _clusters_ EKS con _control-plane_ gestionado. Los grupos de nodos sin _node++_++image_ se aprovisionan ahora como grupos de nodos gestionados por EKS (_AWSManagedMachinePool_) en lugar de instancias EC2 autogestionadas. Un _cluster_ puede combinar ambos tipos en el mismo descriptor.
+* Nuevo campo _ami++_++type_ en _worker++_++nodes_ para seleccionar el tipo de AMI del grupo de nodos gestionado. El valor por defecto es _BOTTLEROCKET_x86_64_.
+* Nuevo campo _mp++_++role++_++name_ en _control_plane.aws_ para asignar un rol IAM preexistente a todos los grupos de nodos gestionados, sin que _Stratio Cloud Provisioner_ cree uno nuevo.
+
 == 0.17.0-0.6 (15 de noviembre de 2024)
 
 * Las réplicas de CoreDNS ahora se distribuyen en nodos diferentes para mejorar la disponibilidad.

--- a/stratio-docs/es/modules/operations-manual/assets/attachments/stratio-aws-temp-policy.json
+++ b/stratio-docs/es/modules/operations-manual/assets/attachments/stratio-aws-temp-policy.json
@@ -12,6 +12,7 @@
                 "iam:CreateInstanceProfile",
                 "iam:CreatePolicy",
                 "iam:CreatePolicyVersion",
+                "iam:DeletePolicyVersion",
                 "iam:CreateRole",
                 "iam:CreateUser",
                 "iam:DeleteGroup",

--- a/stratio-docs/es/modules/operations-manual/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/es/modules/operations-manual/assets/attachments/stratio-eks-policy.json
@@ -153,6 +153,35 @@
               "autoscaling:DeleteTags"
           ],
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroups",
+          "Effect": "Allow",
+          "Action": [
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:DeleteNodegroup"
+          ],
+          "Resource": [
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
+          ]
+      },
+      {
+          "Sid": "CAPAManagedNodegroupsAutoScalingRead",
+          "Effect": "Allow",
+          "Action": [
+              "autoscaling:DescribeAutoScalingGroups"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
+          "Effect": "Allow",
+          "Action": [
+              "iam:CreateServiceLinkedRole"
+          ],
+          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/es/modules/operations-manual/assets/attachments/stratio-eks-policy.json
+++ b/stratio-docs/es/modules/operations-manual/assets/attachments/stratio-eks-policy.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
       {
+          "Sid": "EC2ReadOnly",
           "Effect": "Allow",
           "Action": [
               "ec2:CreateTags",
@@ -34,6 +35,9 @@
               "ecr:GetAuthorizationToken",
               "eks:CreateCluster",
               "eks:DescribeAddon",
+              "eks:CreateNodegroup",
+              "eks:DescribeNodegroup",
+              "eks:UpdateNodegroupConfig",
               "eks:DescribeAddonVersions",
               "eks:UpdateAddon",
               "iam:ListOpenIDConnectProviders"
@@ -41,6 +45,7 @@
           "Resource": "*"
       },
       {
+          "Sid": "EC2WriteResources",
           "Effect": "Allow",
           "Action": [
               "ec2:AllocateAddress",
@@ -65,8 +70,10 @@
               "eks:DescribeCluster",
               "eks:CreateAddon",
               "eks:DeleteCluster",
+              "eks:DeleteNodegroup",
               "eks:ListAddons",
               "eks:TagResource",
+              "eks:UntagResource",
               "eks:UpdateClusterConfig",
               "eks:UpdateClusterVersion",
               "secretsmanager:CreateSecret",
@@ -84,10 +91,12 @@
               "arn:aws:ec2:*:${AWS_ACCOUNT_ID}:vpc/*",
               "arn:aws:ecr:*:*:repository/*",
               "arn:aws:eks:*:${AWS_ACCOUNT_ID}:addon/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*"
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
+              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
           ]
       },
       {
+          "Sid": "EC2SecurityGroups",
           "Effect": "Allow",
           "Action": [
               "ec2:AuthorizeSecurityGroupIngress"
@@ -97,6 +106,7 @@
           ]
       },
       {
+          "Sid": "SSMOptimizedAMI",
           "Effect": "Allow",
           "Action": [
               "ssm:GetParameter"
@@ -106,6 +116,7 @@
           ]
       },
       {
+          "Sid": "IAMAndOIDC",
           "Effect": "Allow",
           "Action": [
               "iam:CreateOpenIDConnectProvider",
@@ -113,13 +124,14 @@
               "iam:GetOpenIDConnectProvider",
               "iam:TagOpenIDConnectProvider",
               "iam:ListAttachedRolePolicies",
+              "iam:CreateServiceLinkedRole",
               "iam:CreateRole",
-              "iam:TagRole",
-              "iam:UntagRole"
+              "iam:TagRole"
           ],
           "Resource": [
               "arn:aws:iam::${AWS_ACCOUNT_ID}:role/*",
-              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*"
+              "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/*",
+              "arn:aws:iam::*:role/aws-service-role/*"
           ]
       },
       {
@@ -155,33 +167,12 @@
           "Resource": "arn:aws:autoscaling:*:${AWS_ACCOUNT_ID}:autoScalingGroup:*:autoScalingGroupName/*"
       },
       {
-          "Sid": "CAPAManagedNodegroups",
-          "Effect": "Allow",
-          "Action": [
-              "eks:CreateNodegroup",
-              "eks:DescribeNodegroup",
-              "eks:DeleteNodegroup"
-          ],
-          "Resource": [
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:cluster/*",
-              "arn:aws:eks:*:${AWS_ACCOUNT_ID}:nodegroup/*/*/*"
-          ]
-      },
-      {
           "Sid": "CAPAManagedNodegroupsAutoScalingRead",
           "Effect": "Allow",
           "Action": [
               "autoscaling:DescribeAutoScalingGroups"
           ],
           "Resource": "*"
-      },
-      {
-          "Sid": "CAPAManagedNodegroupServiceLinkedRole",
-          "Effect": "Allow",
-          "Action": [
-              "iam:CreateServiceLinkedRole"
-          ],
-          "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       }
   ]
 }

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -770,7 +770,7 @@ spec:
   deploy_autoscaler: false
   keos:
     flavour: production
-    version: 1.31.0
+    version: 1.3.x
   security:
     aws:
       create_iam: false
@@ -896,7 +896,7 @@ spec:
       labels: "owner=stratio"
   keos:
     flavour: production
-    version: 1.31.0
+    version: 1.3.x
   control_plane:
     managed: true
     gcp:
@@ -953,8 +953,8 @@ metadata:
 spec:
     private_registry: true
     private_helm_repo: true
-    cluster_operator_version: 0.3.4
-    cluster_operator_image_version: 0.3.4
+    cluster_operator_version: 0.8.x
+    cluster_operator_image_version: 0.8.x
 ----
 
 ==== Azure no gestionado
@@ -1012,7 +1012,7 @@ spec:
     manage_zone: false
   keos:
     flavour: production
-    version: 1.31.0
+    version: 1.3.x
   security:
     control_plane_identity: "/subscriptions/6e2a38cd-../stratio-control-plane"
     nodes_identity: "/subscriptions/6e2a38cd-../stratio-nodes"

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -12,6 +12,8 @@ Para el aprovisionamiento automatizado en EKS, es necesario ejecutar acciones en
 ** xref:attachment$stratio-aws-temp-policy.json[Descargar permisos temporales para EKS]
 +
 Para el despliegue de EKS, se deberá crear manualmente el rol "AWSServiceRoleForAmazonEKS" y asociarle la política "AmazonEKSServiceRolePolicy" (creada por defecto en AWS).
++
+NOTE: Si el _cluster_ incluye grupos de tipo _MachinePool_ (nodegroups gestionados por EKS), el usuario de despliegue necesita permisos adicionales: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups` e `iam:CreateServiceLinkedRole`. Ya están incluidos en `stratio-eks-policy.json`.
 
 * Sistemas operativos certificados
 +

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -715,6 +715,7 @@ En este ejemplo se pueden ver las siguientes particularidades:
 * Se habilitan los _logs_ del _API Server_ en EKS.
 * Uso de grupos de nodos gestionados por EKS (_MachinePool_): los grupos sin _node++_++image_ se crean como _MachinePools_ con AMI gestionada por EKS.
 * Rol IAM preexistente para los grupos de nodos (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ lo asigna sin crear uno nuevo.
+* Coexistencia de grupos gestionados (_MachinePool_) y grupos con AMI personalizada (_MachineDeployment_): el grupo con _node++_++image_ se crea como _MachineDeployment_ (EC2 autogestionado).
 * Grupos de nodos _worker_ con múltiples casuísticas:
 ** Diferentes tipos de instancia.
 ** Con _ami++_++type_ explícito (_BOTTLEROCKET_x86_64_) y con AMI por defecto.
@@ -796,6 +797,8 @@ spec:
       ssh_key: stg-key
     - name: eks-prod-medium-spot
       quantity: 4
+      min_size: 4
+      max_size: 8
       zone_distribution: unbalanced
       size: t3.medium
       spot: true
@@ -803,8 +806,18 @@ spec:
         disktype: standard
     - name: eks-prod-medium-az
       quantity: 3
+      min_size: 3
+      max_size: 6
       size: t3.medium
       az: eu-west-1c
+    - name: eks-prod-custom-ami
+      quantity: 2
+      max_size: 6
+      min_size: 2
+      size: m6i.large
+      node_image: "ami-0a1234567890abcde"
+      labels:
+        workload: custom
 ----
 
 ==== GKE

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -532,13 +532,14 @@ En este apartado se indican las particularidades del _control-plane_ de Kubernet
 ^|Nombre ^|Descripción ^|Ejemplo ^|Opcional
 
 |_aws_
-|Valores específicos para el _logging_ de EKS (_API Server, audit, authenticator, controller++_++manager_ y/o _scheduler_).
+|Valores específicos de EKS. Incluye la configuración del _logging_ del _control-plane_ (_API Server, audit, authenticator, controller++_++manager_ y/o _scheduler_). Opcionalmente, incluye el nombre de un rol IAM preexistente para grupos de nodos gestionados (_mp++_++role++_++name_). Si se especifica, _Stratio Cloud Provisioner_ asigna ese rol a todos los grupos de nodos sin crear uno nuevo.
 a|
 
 [source,yaml]
 ----
 logging:
   api_server: true
+mp_role_name: "eks-nodegroup-role"
 ----
 
 |Sí
@@ -613,8 +614,18 @@ Las imágenes utilizadas deberán estar soportadas por EKS. Consulta la https://
 |Sí
 
 |_node++_++image_
-|Imagen de instancia utilizada para los nodos _worker_.
+|Imagen de instancia personalizada para los nodos _worker_. Si se especifica en un _cluster_ EKS gestionado, el grupo de nodos se crea como _MachineDeployment_ (nodo EC2 autogestionado). Mutuamente exclusivo con _ami++_++type_.
 |ami-0de933c15c9b49fb5
+|Sí
+
+|_ami++_++type_
+|Tipo de AMI para el grupo de nodos gestionado por EKS (_MachinePool_). Solo válido con _control-plane_ gestionado. Si no se especifica, se usa _BOTTLEROCKET_x86_64_ por defecto. Mutuamente exclusivo con _node++_++image_.
+|BOTTLEROCKET_x86_64
+|Sí
+
+|_spot_
+|Activa el uso de instancias _spot_ en el grupo de nodos. Permite reducir costes a cambio de mayor riesgo de interrupción.
+|true
 |Sí
 
 |_labels_
@@ -667,6 +678,8 @@ root_volume:
 
 NOTE: Se ha implementado la opción de establecer un _min++_++size_ igual a cero, lo que permite que el autoescalado pueda incrementar o disminuir el número de nodos hasta alcanzar cero según sea necesario. Esta funcionalidad proporciona un ahorro significativo de costes en comparación con versiones anteriores, ya que permite la definición de un grupo de _workers_ sin instanciar ningún recurso en el proveedor _cloud_ que no sea necesario.
 
+NOTE: En _clusters_ EKS con _control-plane_ gestionado, el tipo de grupo de nodos depende del campo _node++_++image_. Si está presente, se crea un _MachineDeployment_ (EC2 autogestionado). Si no está presente, se crea un _MachinePool_ (grupo gestionado por EKS). Un _cluster_ puede combinar ambos tipos. Para escalar un _MachinePool_ a cero réplicas, _max++_++size_ debe ser mayor o igual al número de zonas de disponibilidad del _cluster_.
+
 === _Stratio KEOS_
 
 Los parámetros para la fase del _keos-installer_ se indicarán en este apartado.
@@ -700,8 +713,11 @@ En este ejemplo se pueden ver las siguientes particularidades:
 * Uso de VPC y _subnets_ personalizadas (creadas anteriormente). Este apartado es opcional.
 * Definición de una _StorageClass_ por defecto. Este apartado es opcional.
 * Se habilitan los _logs_ del _API Server_ en EKS.
+* Uso de grupos de nodos gestionados por EKS (_MachinePool_): los grupos sin _node++_++image_ se crean como _MachinePools_ con AMI gestionada por EKS.
+* Rol IAM preexistente para los grupos de nodos (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ lo asigna sin crear uno nuevo.
 * Grupos de nodos _worker_ con múltiples casuísticas:
 ** Diferentes tipos de instancia.
+** Con _ami++_++type_ explícito (_BOTTLEROCKET_x86_64_) y con AMI por defecto.
 ** Con clave SSH.
 ** Con etiquetas de K8s.
 ** Con rangos de autoescalado.
@@ -762,6 +778,7 @@ spec:
     aws:
       logging:
         api_server: true
+      mp_role_name: "eks-nodegroup-role"
     managed: true
   worker_nodes:
     - name: eks-prod-xlarge
@@ -769,6 +786,7 @@ spec:
       max_size: 18
       min_size: 6
       size: m6i.xlarge
+      ami_type: BOTTLEROCKET_x86_64
       labels:
         disktype: standard
       root_volume:

--- a/stratio-docs/es/modules/operations-manual/pages/installation.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/installation.adoc
@@ -13,7 +13,7 @@ Para el aprovisionamiento automatizado en EKS, es necesario ejecutar acciones en
 +
 Para el despliegue de EKS, se deberá crear manualmente el rol "AWSServiceRoleForAmazonEKS" y asociarle la política "AmazonEKSServiceRolePolicy" (creada por defecto en AWS).
 +
-NOTE: Si el _cluster_ incluye grupos de tipo _MachinePool_ (nodegroups gestionados por EKS), el usuario de despliegue necesita permisos adicionales: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups` e `iam:CreateServiceLinkedRole`. Ya están incluidos en `stratio-eks-policy.json`.
+NOTE: Si el _cluster_ incluye grupos de tipo _MachinePool_ (_nodegroups_ gestionados por EKS), el usuario de despliegue necesita permisos adicionales: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups` e `iam:CreateServiceLinkedRole`. Estos permisos ya están incluidos en el fichero _stratio-eks-policy.json_.
 
 * Sistemas operativos certificados
 +
@@ -534,7 +534,7 @@ En este apartado se indican las particularidades del _control-plane_ de Kubernet
 ^|Nombre ^|Descripción ^|Ejemplo ^|Opcional
 
 |_aws_
-|Valores específicos de EKS. Incluye la configuración del _logging_ del _control-plane_ (_API Server, audit, authenticator, controller++_++manager_ y/o _scheduler_). Opcionalmente, incluye el nombre de un rol IAM preexistente para grupos de nodos gestionados (_mp++_++role++_++name_). Si se especifica, _Stratio Cloud Provisioner_ asigna ese rol a todos los grupos de nodos sin crear uno nuevo.
+|Valores específicos de EKS. Incluye la configuración del _logging_ del _control-plane_ ("api", "audit", "authenticator", "controllerManager" o "scheduler"). Opcionalmente, incluye el nombre de un rol IAM preexistente para los grupos de nodos gestionados (_mp++_++role++_++name_). Si se especifica, _Stratio Cloud Provisioner_ asigna ese rol a todos los grupos de nodos sin crear uno nuevo.
 a|
 
 [source,yaml]
@@ -616,17 +616,17 @@ Las imágenes utilizadas deberán estar soportadas por EKS. Consulta la https://
 |Sí
 
 |_node++_++image_
-|Imagen de instancia personalizada para los nodos _worker_. Si se especifica en un _cluster_ EKS gestionado, el grupo de nodos se crea como _MachineDeployment_ (nodo EC2 autogestionado). Mutuamente exclusivo con _ami++_++type_.
+|Imagen de instancia personalizada para los nodos _worker_. Si se especifica en un cluster EKS gestionado, el grupo de nodos se crea como _MachineDeployment_ (nodo EC2 autogestionado). Es mutuamente excluyente con _ami++_++type_.
 |ami-0de933c15c9b49fb5
 |Sí
 
 |_ami++_++type_
-|Tipo de AMI para el grupo de nodos gestionado por EKS (_MachinePool_). Solo válido con _control-plane_ gestionado. Si no se especifica, se usa _BOTTLEROCKET_x86_64_ por defecto. Mutuamente exclusivo con _node++_++image_.
-|BOTTLEROCKET_x86_64
+|Tipo de AMI para el grupo de nodos gestionado por EKS (_MachinePool_). Solo válido con _control-plane_ gestionado. Si no se especifica, se usa "BOTTLEROCKET++_++x86++_++64" por defecto. Es mutuamente excluyente con _node++_++image_.
+|BOTTLEROCKET++_++x86++_++64
 |Sí
 
 |_spot_
-|Activa el uso de instancias _spot_ en el grupo de nodos. Permite reducir costes a cambio de mayor riesgo de interrupción.
+|Activa el uso de instancias _spot_ en el grupo de nodos. Permite reducir costes a cambio de un mayor riesgo de interrupción.
 |true
 |Sí
 
@@ -680,7 +680,7 @@ root_volume:
 
 NOTE: Se ha implementado la opción de establecer un _min++_++size_ igual a cero, lo que permite que el autoescalado pueda incrementar o disminuir el número de nodos hasta alcanzar cero según sea necesario. Esta funcionalidad proporciona un ahorro significativo de costes en comparación con versiones anteriores, ya que permite la definición de un grupo de _workers_ sin instanciar ningún recurso en el proveedor _cloud_ que no sea necesario.
 
-NOTE: En _clusters_ EKS con _control-plane_ gestionado, el tipo de grupo de nodos depende del campo _node++_++image_. Si está presente, se crea un _MachineDeployment_ (EC2 autogestionado). Si no está presente, se crea un _MachinePool_ (grupo gestionado por EKS). Un _cluster_ puede combinar ambos tipos. Para escalar un _MachinePool_ a cero réplicas, _max++_++size_ debe ser mayor o igual al número de zonas de disponibilidad del _cluster_.
+NOTE: En los clusters EKS con _control-plane_ gestionado, el tipo de grupo de nodos depende del campo _node++_++image_. Si está presente, se crea un _MachineDeployment_ (EC2 autogestionado). Si no está presente, se crea un _MachinePool_ (grupo gestionado por EKS). Un cluster puede combinar ambos tipos. Para escalar un _MachinePool_ a cero réplicas, _max++_++size_ debe ser mayor o igual que el número de zonas de disponibilidad del cluster.
 
 === _Stratio KEOS_
 
@@ -707,22 +707,22 @@ Se presentan dos casos de descriptor para demostrar la capacidad de _Stratio Clo
 
 ==== EKS
 
-En este ejemplo se pueden ver las siguientes particularidades:
+En este ejemplo se aprecian las siguientes particularidades:
 
-* _Cluster_ en AWS con _control-plane_ gestionado (EKS).
+* Cluster en AWS con _control-plane_ gestionado (EKS).
 * Kubernetes versión 1.26.x (EKS no tiene en cuenta la versión _patch_).
-* Uso de ECR como _Docker registry_ (no necesita credenciales).
-* Uso de VPC y _subnets_ personalizadas (creadas anteriormente). Este apartado es opcional.
+* Uso de ECR como _Docker registry_ (no requiere credenciales).
+* Uso de VPC y _subnets_ personalizadas (creadas previamente). Este apartado es opcional.
 * Definición de una _StorageClass_ por defecto. Este apartado es opcional.
 * Se habilitan los _logs_ del _API Server_ en EKS.
-* Uso de grupos de nodos gestionados por EKS (_MachinePool_): los grupos sin _node++_++image_ se crean como _MachinePools_ con AMI gestionada por EKS.
+* Uso de grupos de nodos gestionados por EKS (_MachinePool_): los grupos sin _node++_++image_ se crean como _MachinePools_ con una AMI gestionada por EKS.
 * Rol IAM preexistente para los grupos de nodos (_mp++_++role++_++name_): _Stratio Cloud Provisioner_ lo asigna sin crear uno nuevo.
 * Coexistencia de grupos gestionados (_MachinePool_) y grupos con AMI personalizada (_MachineDeployment_): el grupo con _node++_++image_ se crea como _MachineDeployment_ (EC2 autogestionado).
-* Grupos de nodos _worker_ con múltiples casuísticas:
+* Grupos de nodos _worker_ con varias casuísticas:
 ** Diferentes tipos de instancia.
-** Con _ami++_++type_ explícito (_BOTTLEROCKET_x86_64_) y con AMI por defecto.
+** Con _ami++_++type_ explícito ("BOTTLEROCKET++_++x86++_++64") y con AMI por defecto.
 ** Con clave SSH.
-** Con etiquetas de K8s.
+** Con etiquetas de Kubernetes.
 ** Con rangos de autoescalado.
 ** En una zona fija.
 ** Con personalizaciones en el disco.

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -197,72 +197,6 @@ Esto implica que:
 
 WARNING: El _flag_ `--private` solo es necesario si quieres *forzar el uso de repositorios privados* y el `ClusterConfig` actual ya no lo tiene habilitado.
 
-=== _Clusters_ EKS con _MachinePools_
-
-NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
-
-==== Migración de _MachineDeployments_ a _MachinePools_
-
-WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
-
-La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
-
-===== Prerequisitos
-
-* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
-* `KeosCluster.status.ready = true`.
-
-Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
-
-===== Fase 1 — Preparación del _cluster_
-
-IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
-
-Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
-
-[source,bash]
-----
-python3 migrate-workers-to-machinepool.py \
-  --kubeconfig ~/.kube/config
-----
-
-El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
-
-El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
-
-===== Fase 2 — Migración de grupos de nodos
-
-Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
-
-. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
-+
-[source,bash]
-----
-kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
-  --type=json \
-  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
-----
-+
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
-
-. Espera a que los nodos MP estén en estado `Ready`.
-
-. Verifica la capacidad y obtén los comandos de drenado:
-+
-[source,bash]
-----
-python3 migrate-workers-to-machinepool.py \
-  --check-ready <nombre>-mp
-----
-+
-El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
-
-. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
-
-. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
-
-NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
-
 == Uso del _script_ de actualización
 
 === Sintaxis
@@ -451,4 +385,70 @@ kubectl get machinepools -A
 kubectl get nodes
 # Verificar que los logs de CAPX no contengan errores tras la actualización
 ----
+
+== _Clusters_ EKS con _MachinePools_
+
+NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
+
+=== Migración de _MachineDeployments_ a _MachinePools_
+
+WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
+
+La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
+
+==== Prerequisitos
+
+* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
+* `KeosCluster.status.ready = true`.
+
+Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
+
+==== Fase 1 — Preparación del _cluster_
+
+IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
+
+Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
+
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --kubeconfig ~/.kube/config
+----
+
+El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
+
+El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
+
+==== Fase 2 — Migración de grupos de nodos
+
+Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
+
+. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
++
+[source,bash]
+----
+kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
+----
++
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
+
+. Espera a que los nodos MP estén en estado `Ready`.
+
+. Verifica la capacidad y obtén los comandos de drenado:
++
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --check-ready <nombre>-mp
+----
++
+El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
+
+. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
+
+. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
+
+NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -201,16 +201,6 @@ WARNING: El _flag_ `--private` solo es necesario si quieres *forzar el uso de re
 
 NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
 
-==== _MachineDeployments_ (con _node++_++image_)
-
-La imagen de nodo es fija. Al cambiar _k8s++_++version_ en el descriptor, solo se actualiza el _control-plane_. Para actualizar los nodos de tipo _MachineDeployment_:
-
-. Obtén el identificador de la AMI para la nueva versión de Kubernetes en la región del _cluster_.
-. Actualiza el campo _node++_++image_ de cada grupo afectado en el descriptor.
-. Aplica el descriptor actualizado con Stratio Cloud Provisioner.
-
-NOTE: Si no actualizas _node++_++image_, los nodos de tipo _MachineDeployment_ mantienen la versión de _kubelet_ de la AMI anterior. El _control-plane_ puede estar en una versión superior a la de esos nodos.
-
 ==== Migración de _MachineDeployments_ a _MachinePools_
 
 WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -400,6 +400,7 @@ La migración es un proceso asistido y por fases. El _script_ `migrate-workers-t
 
 * cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
 * `KeosCluster.status.ready = true`.
+* La política EKS del usuario de despliegue debe incluir los permisos de gestión de nodegroups de `stratio-eks-policy.json` (`eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, `iam:CreateServiceLinkedRole`).
 
 Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -436,7 +436,7 @@ NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` pa
 
 . Espera a que los nodos MP estén en estado `Ready`.
 
-. Verifica la capacidad y obtén los comandos de drenado:
+. Verifica la capacidad y obtén las instrucciones de drenado y eliminación:
 +
 [source,bash]
 ----
@@ -444,11 +444,11 @@ python3 migrate-workers-to-machinepool.py \
   --check-ready <nombre>-mp
 ----
 +
-El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
+El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente, y las instrucciones para eliminar la entrada del grupo MD del objeto `KeosCluster`. Revisa las instrucciones antes de ejecutarlas.
 
 . Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
 
-. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
+. Sigue las instrucciones que imprime el _script_ para eliminar el grupo MD del objeto `KeosCluster`.
 
 NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -408,7 +408,6 @@ Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner
 
 IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de _cluster-operator_ de esta versión estén disponibles en el registro de contenedores y en el repositorio de Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se hayan publicado antes de continuar.
 
-
 Ejecuta el _script_ de preparación dentro del contenedor de _Stratio Cloud Provisioner_:
 
 [source,bash]

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -243,7 +243,7 @@ kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
   -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
 +
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator interpreta un `apply` como la primera reconciliación del _cluster_ y actualiza la anotación de estado sin ejecutar los cambios reales sobre la infraestructura.
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
 
 . Espera a que los nodos MP estén en estado `Ready`.
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -243,7 +243,7 @@ kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
   -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
 +
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`.
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator interpreta un `apply` como la primera reconciliación del _cluster_ y actualiza la anotación de estado sin ejecutar los cambios reales sobre la infraestructura.
 
 . Espera a que los nodos MP estén en estado `Ready`.
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -244,20 +244,18 @@ El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`Machi
 
 Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
 
-. Añade el nuevo grupo MP al descriptor. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
+. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
 +
-[source,yaml]
+[source,bash]
 ----
-worker_nodes:
-  - name: <nombre>-mp
-    size: <mismo-size>
-    quantity: <misma-cantidad>
-    az: <misma-az>
-    ami_type: BOTTLEROCKET_x86_64   # opcional
-    labels: {}                       # mismas labels que el grupo MD
+kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
++
+NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`.
 
-. Aplica el descriptor con Stratio Cloud Provisioner y espera a que los nodos MP estén en estado `Ready`.
+. Espera a que los nodos MP estén en estado `Ready`.
 
 . Verifica la capacidad y obtén los comandos de drenado:
 +
@@ -271,7 +269,7 @@ El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivale
 
 . Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
 
-. Elimina el grupo MD del descriptor y aplícalo con Stratio Cloud Provisioner.
+. Elimina el grupo MD del objeto `KeosCluster` mediante un JSON patch con la operación `remove`, indicando el índice del elemento en el array `worker_nodes`.
 
 NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
 

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -197,6 +197,84 @@ Esto implica que:
 
 WARNING: El _flag_ `--private` solo es necesario si quieres *forzar el uso de repositorios privados* y el `ClusterConfig` actual ya no lo tiene habilitado.
 
+=== _Clusters_ EKS con _MachinePools_
+
+NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
+
+==== _MachineDeployments_ (con _node++_++image_)
+
+La imagen de nodo es fija. Al cambiar _k8s++_++version_ en el descriptor, solo se actualiza el _control-plane_. Para actualizar los nodos de tipo _MachineDeployment_:
+
+. Obtén el identificador de la AMI para la nueva versión de Kubernetes en la región del _cluster_.
+. Actualiza el campo _node++_++image_ de cada grupo afectado en el descriptor.
+. Aplica el descriptor actualizado con Stratio Cloud Provisioner.
+
+NOTE: Si no actualizas _node++_++image_, los nodos de tipo _MachineDeployment_ mantienen la versión de _kubelet_ de la AMI anterior. El _control-plane_ puede estar en una versión superior a la de esos nodos.
+
+==== Migración de _MachineDeployments_ a _MachinePools_
+
+WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
+
+La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
+
+===== Prerequisitos
+
+* cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
+* `KeosCluster.status.ready = true`.
+
+Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
+
+===== Fase 1 — Preparación del _cluster_
+
+IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
+
+Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
+
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --kubeconfig ~/.kube/config
+----
+
+El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
+
+El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
+
+===== Fase 2 — Migración de grupos de nodos
+
+Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
+
+. Añade el nuevo grupo MP al descriptor. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
++
+[source,yaml]
+----
+worker_nodes:
+  - name: <nombre>-mp
+    size: <mismo-size>
+    quantity: <misma-cantidad>
+    az: <misma-az>
+    ami_type: BOTTLEROCKET_x86_64   # opcional
+    labels: {}                       # mismas labels que el grupo MD
+----
+
+. Aplica el descriptor con Stratio Cloud Provisioner y espera a que los nodos MP estén en estado `Ready`.
+
+. Verifica la capacidad y obtén los comandos de drenado:
++
+[source,bash]
+----
+python3 migrate-workers-to-machinepool.py \
+  --check-ready <nombre>-mp
+----
++
+El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente.
+
+. Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
+
+. Elimina el grupo MD del descriptor y aplícalo con Stratio Cloud Provisioner.
+
+NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
+
 == Uso del _script_ de actualización
 
 === Sintaxis

--- a/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
+++ b/stratio-docs/es/modules/operations-manual/pages/upgrade.adoc
@@ -388,27 +388,28 @@ kubectl get nodes
 
 == _Clusters_ EKS con _MachinePools_
 
-NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de Stratio Cloud Provisioner. No existe migración automática desde _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta <<_migración_de_machinedeployments_a_machinepools,Migración de _MachineDeployments_ a _MachinePools_>>.
+NOTE: Los _MachinePools_ solo están disponibles en _clusters_ creados con esta versión de _Stratio Cloud Provisioner_. No existe migración automática de _MachineDeployments_ a _MachinePools_ en _clusters_ existentes. Para migrar un _cluster_ existente, consulta la <<_migración_de_machinedeployments_a_machinepools, migración de _MachineDeployments_ a _MachinePools_>>.
 
 === Migración de _MachineDeployments_ a _MachinePools_
 
-WARNING: Este procedimiento aplica únicamente a _clusters_ *EKS* (AWS gestionado). No está disponible para Azure VMs ni GKE.
+WARNING: Este procedimiento se aplica únicamente a _clusters_ EKS (AWS gestionado). No está disponible para Azure VMs ni para GKE.
 
-La migración es un proceso asistido y por fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, a un ritmo decidido por el operador.
+La migración es un proceso asistido y en fases. El _script_ `migrate-workers-to-machinepool.py` prepara el _cluster_ y valida la capacidad antes de cada drenado. Los nodos se migran manualmente, uno a uno, al ritmo que decidas.
 
-==== Prerequisitos
+==== Prerrequisitos
 
 * cluster-operator >= 0.6.1 y CAPA >= v2.9.2 en el _cluster_.
 * `KeosCluster.status.ready = true`.
-* La política EKS del usuario de despliegue debe incluir los permisos de gestión de nodegroups de `stratio-eks-policy.json` (`eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, `iam:CreateServiceLinkedRole`).
+* La política EKS del usuario de despliegue debe incluir los permisos de gestión de _nodegroups_ del fichero _stratio-eks-policy.json_: `eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups` e `iam:CreateServiceLinkedRole`.
 
-Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py` antes de continuar.
+Si el _cluster_ tiene versiones anteriores, ejecuta primero `upgrade-provisioner.py`.
 
-==== Fase 1 — Preparación del _cluster_
+==== Fase 1: preparación del _cluster_
 
-IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de cluster-operator de este release estén disponibles en el registro de contenedores y en el repositorio Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se han publicado antes de continuar.
+IMPORTANT: Antes de ejecutar el _script_, verifica que la imagen y el _chart_ de _cluster-operator_ de esta versión estén disponibles en el registro de contenedores y en el repositorio de Helm configurados para el _cluster_. Si el _cluster_ usa registros privados (`private_registry=true` o `private_helm_repo=true`), asegúrate de que los artefactos se hayan publicado antes de continuar.
 
-Ejecuta el _script_ de preparación dentro del contenedor de Stratio Cloud Provisioner:
+
+Ejecuta el _script_ de preparación dentro del contenedor de _Stratio Cloud Provisioner_:
 
 [source,bash]
 ----
@@ -416,15 +417,15 @@ python3 migrate-workers-to-machinepool.py \
   --kubeconfig ~/.kube/config
 ----
 
-El _script_ usa por defecto la versión de cluster-operator incluida en este release de Stratio Cloud Provisioner. Puedes sobreescribirla con `--cluster-operator-version <versión>` si es necesario.
+El _script_ usa por defecto la versión de _cluster-operator_ incluida en esta versión de _Stratio Cloud Provisioner_. Puedes sobrescribirla con `--cluster-operator-version <versión>` si es necesario.
 
-El _script_ valida los prerequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza cluster-operator a la versión indicada.
+El _script_ valida los prerrequisitos, activa los _feature gates_ de CAPA (`MachinePool=true` y `EKSAllowAddRoles=true`) y actualiza el _cluster-operator_ a la versión indicada.
 
-==== Fase 2 — Migración de grupos de nodos
+==== Fase 2: migración de grupos de nodos
 
-Repite los pasos siguientes para cada grupo de nodos que quieras migrar:
+Repite los siguientes pasos para cada grupo de nodos que quieras migrar:
 
-. Añade el nuevo grupo MP al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto `BOTTLEROCKET_x86_64`):
+. Añade el nuevo grupo _MachinePool_ al objeto `KeosCluster`. Omite `node_image` e indica `ami_type` de forma opcional (por defecto, "BOTTLEROCKET_x86_64"):
 +
 [source,bash]
 ----
@@ -433,10 +434,9 @@ kubectl patch keoscluster <nombre-cluster> -n cluster-<nombre-cluster> \
   -p '[{"op":"add","path":"/spec/worker_nodes/-","value":{"name":"<nombre>-mp","size":"<size>","quantity":<n>,"az":"<az>","min_size":<min>,"max_size":<max>}}]'
 ----
 +
-NOTE: Usa `--type=json` con la operación `add` y path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: cluster-operator detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera el `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
+NOTE: Usa `--type=json` con la operación `add` y el path `/spec/worker_nodes/-` para añadir el grupo sin reemplazar los existentes. Nunca uses `kubectl apply` sobre el `KeosCluster`: _cluster-operator_ detecta la anotación `kubectl.kubernetes.io/last-applied-configuration` que genera `apply` y salta el ciclo de reconciliación real, por lo que los cambios en `spec.worker_nodes` nunca se procesan.
 
-. Espera a que los nodos MP estén en estado `Ready`.
-
+. Espera a que los nodos de _MachinePool_ estén en estado _Ready_.
 . Verifica la capacidad y obtén las instrucciones de drenado y eliminación:
 +
 [source,bash]
@@ -445,11 +445,9 @@ python3 migrate-workers-to-machinepool.py \
   --check-ready <nombre>-mp
 ----
 +
-El _script_ imprime los comandos de drenado para cada nodo del grupo MD equivalente, y las instrucciones para eliminar la entrada del grupo MD del objeto `KeosCluster`. Revisa las instrucciones antes de ejecutarlas.
+El _script_ imprime los comandos de drenado para cada nodo del grupo _MachineDeployment_ equivalente, así como las instrucciones para eliminar la entrada de ese grupo del objeto `KeosCluster`. Revisa las instrucciones antes de ejecutarlas.
 
 . Ejecuta los comandos de drenado que imprime el _script_, uno a uno. Verifica el estado del _cluster_ entre cada nodo.
+. Sigue las instrucciones que imprime el _script_ para eliminar el grupo _MachineDeployment_ del objeto `KeosCluster`.
 
-. Sigue las instrucciones que imprime el _script_ para eliminar el grupo MD del objeto `KeosCluster`.
-
-NOTE: No elimines el grupo MD hasta que todos sus nodos estén drenados y el grupo MP tenga capacidad suficiente para absorber la carga de trabajo.
-
+NOTE: No elimines el grupo _MachineDeployment_ hasta que todos sus nodos estén drenados y el grupo _MachinePool_ tenga capacidad suficiente para absorber la carga de trabajo.


### PR DESCRIPTION
## [PLT-4103] Documentación MachinePools + permisos EKS para nodegroups gestionados

### Description
Documenta la feature MachinePool (PLT-3962) en `stratio-docs/` (ES+EN): campos nuevos en `installation.adoc`, sección de upgrade en `upgrade.adoc`, entrada en release notes, y ejemplo combinado MP+MD en el descriptor. Incluye además los permisos IAM de `stratio-eks-policy.json` (4 copias) confirmados mediante despliegue real necesarios para el ciclo de vida de nodegroups gestionados por EKS (`eks:CreateNodegroup`, `eks:DescribeNodegroup`, `eks:DeleteNodegroup`, `autoscaling:DescribeAutoScalingGroups`, `iam:CreateServiceLinkedRole`).

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### Related Pull Requests
- Stratio/cluster-operator#332 — fix de webhook (`max_size`/`min_size`) y anotaciones del cluster-autoscaler para MachinePool relacionados

### How Has This Been Tested?
- Permisos IAM validados en vivo mediante despliegue real de un cluster EKS mixto MP+MD (ver `Tasks/PLT-3962/PLT-4103/permisos-machine-pools.md`) — cero `AccessDenied` con la policy actualizada.
- Ejemplos de descriptor y contenido de doc no requieren build, solo revisión editorial.

### Checklist:
- [x] [PR title] Title references a Jira ticket.
- [x] [PR desc] Summary of changes included.
- [x] [PR desc] Related PRs listed.
- [x] Self-review performed.

### Additional Notes
**Pendiente de testear pruebas de upgrade** — falta validar el flujo de `upgrade.adoc` con estos cambios y los permisos nuevos de `stratio-eks-policy.json` en un escenario de migración real. Marcada como `wip` hasta cerrar esa prueba.

Queda pendiente completar la documentación con los hallazgos de PLT-4265 (Upgrade k8s 1.35 - cloud-provisioner-0.9.X) que afecten a MachinePools — se incorporará cuando arranque esa tarea, como último paso de PLT-4103.

[PLT-4103]: https://stratio.atlassian.net/browse/PLT-4103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ