### PR TITLE
[PLT-4515] Report the real milestone/release version instead of always SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.9.0 (upcoming)
 
+* [PLT-4515] Fix change-version.sh hardcoding versionPreRelease to SNAPSHOT regardless of the version passed by the release pipeline; the binary now reports its real milestone/release/pre-release version (e.g. `0.9.0-m.3`) instead of always `X.Y.Z-SNAPSHOT.N+hash`
 * [PLT-4334] Fix cloud-provisioner crash when CloudFormation stack has no updates to perform (ignore "No updates are to be performed" error from clusterawsadm as success)
 * [PLT-4131] Add kubeconfig secret recovery runbooks for GKE (CAPG), EKS (CAPA) and Azure VMs (CAPZ/KCP) in docs/
 * [PLT-4264] Downgrade flux2 chart 2.18.4→2.17.2 and components (helm-controller v1.4.5, source-controller v1.7.4, kustomize-controller v1.7.3, flux-cli v2.7.5) for all providers and k8s supported minors

--- a/bin/change-version.sh
+++ b/bin/change-version.sh
@@ -12,9 +12,13 @@ fi
 
 VERSION_GO_FILE="$BASEDIR/pkg/cmd/kind/version/version.go"
 CORE_VERSION=$(echo "$VERSION" | sed -E "s/-.*//")
+# PLT-4515: propagate the real pre-release label (m.3, BUILD, M, or empty for a
+# final release) instead of hardcoding SNAPSHOT, so milestone/release builds
+# report their true semver without depending on git tags existing at build time.
+PRE_RELEASE=$(echo "$VERSION" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+(-(.+))?$/\2/')
 
 echo "Modifying cloud-provisioner version to: $1"
 echo $VERSION > $BASEDIR/VERSION
 
 sed -i "s/\(const versionCore = \"\)[^\"]*\"/\1$CORE_VERSION\"/" "$VERSION_GO_FILE"
-sed -i "s/\(const versionPreRelease = \"\)[^\"]*\"/\1SNAPSHOT\"/" "$VERSION_GO_FILE"
+sed -i "s/\(var versionPreRelease = \"\)[^\"]*\"/\1$PRE_RELEASE\"/" "$VERSION_GO_FILE"

--- a/pkg/cmd/kind/version/version.go
+++ b/pkg/cmd/kind/version/version.go
@@ -37,8 +37,11 @@ func Version(useGitCommit bool) string {
 			v = gitTag
 		} else {
 			// Build semver pre-release: SNAPSHOT[.commitCount]
+			// PLT-4515: only append the commit count for a real continuous-dev
+			// SNAPSHOT build. Named labels (milestones, BUILD, ...) already fully
+			// identify the build and must not get an extra ".N" suffix appended.
 			preRelease := versionPreRelease
-			if gitCommitCount != "" {
+			if versionPreRelease == "SNAPSHOT" && gitCommitCount != "" {
 				preRelease += "." + gitCommitCount
 			}
 			v += "-" + preRelease
@@ -62,8 +65,9 @@ func DisplayVersion() string {
 const versionCore = "0.9.0"
 
 // versionPreRelease is the base pre-release portion of the kind CLI version per
-// Semantic Versioning 2.0.0
-const versionPreRelease = "SNAPSHOT"
+// Semantic Versioning 2.0.0. It is a var (not const) so PLT-4515 tests can vary
+// it directly; change-version.sh still sets it via sed before compilation.
+var versionPreRelease = "SNAPSHOT"
 
 // gitTag is the git tag used to build the kind binary, if available.
 // It is injected at build time.

--- a/pkg/cmd/kind/version/version_test.go
+++ b/pkg/cmd/kind/version/version_test.go
@@ -116,3 +116,69 @@ func TestVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestVersionPreReleaseLabels covers PLT-4515: change-version.sh now propagates
+// the real pre-release label (milestone, BUILD, or empty for a final release)
+// instead of hardcoding SNAPSHOT, and Version() must only append gitCommitCount
+// for a real "SNAPSHOT" continuous-dev build, never for a named label.
+func TestVersionPreReleaseLabels(t *testing.T) {
+	tests := []struct {
+		name              string
+		versionPreRelease string
+		gitCommitCount    string
+		want              string
+	}{
+		{
+			name:              "Final release: empty pre-release, no suffix at all",
+			versionPreRelease: "",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore,
+		},
+		{
+			name:              "Milestone label: commit count must NOT be appended",
+			versionPreRelease: "m.3",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore + "-m.3",
+		},
+		{
+			name:              "BUILD label: commit count must NOT be appended",
+			versionPreRelease: "BUILD",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore + "-BUILD",
+		},
+		{
+			name:              "Milestone label without a commit count: unaffected",
+			versionPreRelease: "M",
+			gitCommitCount:    "",
+			want:              versionCore + "-M",
+		},
+		{
+			name:              "Real SNAPSHOT: commit count IS appended (unchanged behavior)",
+			versionPreRelease: "SNAPSHOT",
+			gitCommitCount:    "mocked-count",
+			want:              versionCore + "-SNAPSHOT.mocked-count",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preReleaseBackup := versionPreRelease
+			versionPreRelease = tt.versionPreRelease
+			defer func() {
+				versionPreRelease = preReleaseBackup
+			}()
+
+			gitCommitCountBackup := gitCommitCount
+			gitCommitCount = tt.gitCommitCount
+			defer func() {
+				gitCommitCount = gitCommitCountBackup
+			}()
+
+			// useGitCommit=false and gitCommit="" throughout: isolates the
+			// pre-release/commit-count logic from the "+hash" build metadata,
+			// already covered by TestVersion above.
+			if got := Version(false); got != tt.want {
+				t.Errorf("Version() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## [PLT-4515] Report the real milestone/release version instead of always SNAPSHOT

### Description
`bin/change-version.sh` hardcoded `versionPreRelease` to `"SNAPSHOT"` regardless of the version string passed by the release pipeline, discarding the real label (`m.3`, `BUILD`, `M`, or empty for a final release). Combined with the git-tag-based fallback in the Makefile (`git describe --exact-match --tags`, which can never match because the pipeline creates the release tag only *after* building — verified with the full Jenkins log for `Release/Clouds/kind #285`), the published binary always reported `X.Y.Z-SNAPSHOT.N+hash` instead of its real version (e.g. `0.9.0-m.3`), breaking `docker pull`/binary consumption by version tag.

- `bin/change-version.sh` now extracts the actual pre-release label from `$VERSION` instead of hardcoding `SNAPSHOT`.
- `pkg/cmd/kind/version/version.go`: `versionPreRelease` is now a `var` (was `const`) so it can be exercised directly in tests. `Version()` only appends `gitCommitCount` for a real `"SNAPSHOT"` continuous-dev build, never for a named label (milestone/BUILD/final release).
- Added `TestVersionPreReleaseLabels` covering the Final Release / Pre-release-BUILD / Milestone (numbered and unnumbered) / SNAPSHOT matrix.

Verified against all `NEXT_VERSION` formats the release pipeline can produce, confirmed by reading the actual pipeline source in `Stratio/continuous-delivery-tng`: Final Release, Pre-release/BUILD, Milestone (numbered `m.N` and unnumbered `M`), and the branch-cut SNAPSHOT bump — the `X#Y` branching pattern is split by the pipeline itself (`StratioVersioning.groovy`) into a plain `Y.0-SNAPSHOT` string before `change-version.sh` ever runs, so it's already covered by the SNAPSHOT case.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Related Pull Requests
- None

### How Has This Been Tested?
- Unit tests: `go test ./pkg/cmd/kind/version/...` — 10/10 PASS (existing `TestVersion`/`TestTruncate` unaffected, new `TestVersionPreReleaseLabels` covers 5 cases).
- Local shell test matrix exercising the real `change-version.sh` against all 5 `NEXT_VERSION` formats — 5/5 OK (before the fix: 4/5 FAIL, reproducing the bug).
- Real `make build` end-to-end for two cases: `0.9.0-m.3` → `cloud-provisioner Version:0.9.0-m.3+2fea3387`; `0.1.0` → `cloud-provisioner Version:0.1.0`.

### Checklist:
- [x] [PR title] Title references a Jira ticket.
- [x] [PR desc] Summary of changes included.
- [x] [PR desc] Related PRs listed (docs, tests, etc.) — none needed.
- [x] [PR labels] `ai-assisted` applied.
- [x] [QA] Unit tests included in this PR.
- [x] Code follows project style guidelines.
- [x] Self-review performed.

### Additional Notes
CHANGELOG.md updated under `0.9.0 (upcoming)`.

[PLT-4515]: https://stratio.atlassian.net/browse/PLT-4515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ